### PR TITLE
rename GOFLAGS to GOLDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ LDFLAGS += -X "github.com/pingcap/dumpling/v4/cli.GitBranch=$(shell git rev-pars
 LDFLAGS += -X "github.com/pingcap/dumpling/v4/cli.GoVersion=$(shell go version)"
 
 GO = go
-GOFLAGS = -ldflags '$(LDFLAGS)'
+GOLDFLAGS = -ldflags '$(LDFLAGS)'
 ifeq ("$(WITH_RACE)", "1")
-	GOFLAGS += -race
+	GOLDFLAGS += -race
 endif
 
 .PHONY: build test
@@ -15,7 +15,7 @@ endif
 build: bin/dumpling
 
 bin/%: cmd/%/main.go $(wildcard v4/**/*.go)
-	$(GO) build $(GOFLAGS) -tags codes -o $@ $<
+	$(GO) build $(GOLDFLAGS) -tags codes -o $@ $<
 
 test:
-	$(GO) list ./... | xargs $(GO) test $(GOFLAGS) -coverprofile=coverage.txt -covermode=atomic
+	$(GO) list ./... | xargs $(GO) test $(GOLDFLAGS) -coverprofile=coverage.txt -covermode=atomic


### PR DESCRIPTION
Here is the output when I run `make test`:
```
go list ./... | xargs go test -ldflags '-X "github.com/pingcap/dumpling/v4/cli.ReleaseVersion=6342838-dev" -X "github.com/pingcap/dumpling/v4/cli.BuildTimestamp=2019-12-27 03:20:19" -X "github.com/pingcap/dumpling/v4/cli.GitHash=6342838472f82a8dd141930b4b4a843cc71e3855" -X "github.com/pingcap/dumpling/v4/cli.GitBranch=HEAD" -X "github.com/pingcap/dumpling/v4/cli.GoVersion=go version go1.13.4 linux/amd64"' -coverprofile=coverage.txt -covermode=atomic
go: parsing $GOFLAGS: non-flag "'-X"
go: parsing $GOFLAGS: non-flag "'-X"
make: *** [Makefile:21: test] Error 123
```
It seems the error is related to `$GOFLAGS` [environment variable](https://go-review.googlesource.com/c/go/+/126656/).

Renaming `GOFLAGS` can solve this problem.