### PR TITLE
support sorting output by primary key

### DIFF
--- a/cmd/dumpling/main.go
+++ b/cmd/dumpling/main.go
@@ -57,11 +57,13 @@ func init() {
 	flag.Uint64Var(&fileSize, "F", export.UnspecifiedSize, "The approximate size of output file")
 	flag.Uint64Var(&fileSize, "filesize", export.UnspecifiedSize, "The approximate size of output file")
 
-	flag.StringVar(&outputDir, "output", defaultOutputDir(), "Output directory")
-	flag.StringVar(&outputDir, "o", defaultOutputDir(), "Output directory")
+	flag.StringVar(&outputDir, "output", defaultOutputDir, "Output directory")
+	flag.StringVar(&outputDir, "o", defaultOutputDir, "Output directory")
 }
 
-func defaultOutputDir() string {
+var defaultOutputDir = timestampDirName()
+
+func timestampDirName() string {
 	return fmt.Sprintf("./export-%s", time.Now().Format(time.RFC3339))
 }
 

--- a/cmd/dumpling/main.go
+++ b/cmd/dumpling/main.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	_ "net/http/pprof"
 	"os"
+	"time"
 
 	"github.com/pingcap/dumpling/v4/cli"
 	"github.com/pingcap/dumpling/v4/export"
@@ -56,8 +57,12 @@ func init() {
 	flag.Uint64Var(&fileSize, "F", export.UnspecifiedSize, "The approximate size of output file")
 	flag.Uint64Var(&fileSize, "filesize", export.UnspecifiedSize, "The approximate size of output file")
 
-	flag.StringVar(&outputDir, "output", ".", "Output directory")
-	flag.StringVar(&outputDir, "o", ".", "Output directory")
+	flag.StringVar(&outputDir, "output", defaultOutputDir(), "Output directory")
+	flag.StringVar(&outputDir, "o", defaultOutputDir(), "Output directory")
+}
+
+func defaultOutputDir() string {
+	return fmt.Sprintf("./export-%s", time.Now().Format(time.RFC3339))
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/pingcap/dumpling
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.3.3
+	github.com/coreos/go-semver v0.3.0
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/pingcap/check v0.0.0-20191107115940-caf2b9e6ccf4
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/pingcap/dumpling
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.3.3
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/pingcap/check v0.0.0-20191107115940-caf2b9e6ccf4
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
+github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,12 @@
-github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
-github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
+github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
+github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -2,6 +2,9 @@ package export
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
 )
 
 type Config struct {
@@ -15,6 +18,8 @@ type Config struct {
 	Logger        Logger
 	FileSize      uint64
 	OutputDirPath string
+	ServerInfo    ServerInfo
+	SortByPk      bool
 }
 
 func DefaultConfig() *Config {
@@ -28,6 +33,8 @@ func DefaultConfig() *Config {
 		Logger:        &DummyLogger{},
 		FileSize:      UnspecifiedSize,
 		OutputDirPath: ".",
+		ServerInfo:    UnknownServerInfo,
+		SortByPk:      false,
 	}
 }
 
@@ -35,21 +42,76 @@ func (conf *Config) getDSN(db string) string {
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", conf.User, conf.Password, conf.Host, conf.Port, db)
 }
 
-func extractOutputConfig(conf *Config) *Config {
-	return &Config{
-		Logger:        conf.Logger,
-		FileSize:      conf.FileSize,
-		OutputDirPath: conf.OutputDirPath,
+const UnspecifiedSize = 0
+
+type ServerInfo struct {
+	ServerType    ServerType
+	ServerVersion *ServerVersion
+}
+
+var UnknownServerInfo = ServerInfo{
+	ServerType:    UnknownServerType,
+	ServerVersion: nil,
+}
+
+var versionRegex = regexp.MustCompile("^(\\d+\\.){2}\\d+")
+var tidbVersionRegex = regexp.MustCompile("v(\\d+\\.){2}\\d+")
+
+func ParseServerInfo(versionStr string) (ServerInfo, error) {
+	lowerCase := strings.ToLower(versionStr)
+	serverInfo := ServerInfo{}
+	if strings.Contains(lowerCase, "tidb") {
+		serverInfo.ServerType = TiDBServerType
+	} else if strings.Contains(lowerCase, "mariadb") {
+		serverInfo.ServerType = MariaDBServerType
+	} else if versionRegex.MatchString(lowerCase) {
+		serverInfo.ServerType = MySQLServerType
+	} else {
+		serverInfo.ServerType = UnknownServerType
+	}
+
+	var trimmedVersionStr string
+	if serverInfo.ServerType == TiDBServerType {
+		trimmedVersionStr = tidbVersionRegex.FindString(versionStr)[1:]
+	} else {
+		trimmedVersionStr = versionRegex.FindString(versionStr)
+	}
+	versionNums := strings.Split(trimmedVersionStr, ".")
+	if len(versionNums) != 3 {
+		return serverInfo, nil
+	}
+	var vs [3]int
+	var err error
+	for i, s := range versionNums {
+		vs[i], err = strconv.Atoi(s)
+		if err != nil {
+			return serverInfo, err
+		}
+	}
+
+	serverInfo.ServerVersion = makeServerVersion(vs[0], vs[1], vs[2])
+	return serverInfo, nil
+}
+
+type ServerType int8
+
+const (
+	UnknownServerType = iota
+	MySQLServerType
+	MariaDBServerType
+	TiDBServerType
+)
+
+type ServerVersion struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+func makeServerVersion(major, minor, patch int) *ServerVersion {
+	return &ServerVersion{
+		Major: major,
+		Minor: minor,
+		Patch: patch,
 	}
 }
-
-type WriteConfig struct {
-	// Logger is used to log the export routine.
-	Logger Logger
-	// Output size limit in bytes.
-	OutputSize int
-	// OutputDirPath is the directory to output.
-	OutputDirPath string
-}
-
-const UnspecifiedSize = 0

--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -93,4 +93,6 @@ const (
 	ServerTypeMySQL
 	ServerTypeMariaDB
 	ServerTypeTiDB
+
+	ServerTypeAll
 )

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -258,7 +258,7 @@ const errBadFieldCode = 1054
 
 func buildOrderByClause(conf *Config, db *sql.DB, database, table string) (string, error) {
 	if conf.ServerInfo.ServerType == ServerTypeTiDB {
-		tiDBRowIDQuery := fmt.Sprintf("SELECT _tidb_rowid from %s.%s", database, table)
+		tiDBRowIDQuery := fmt.Sprintf("SELECT _tidb_rowid from %s.%s LIMIT 0", database, table)
 		isBadField, otherErr := queryReturnExpectedErrorCode(db, tiDBRowIDQuery, errBadFieldCode)
 		if otherErr != nil {
 			return "", otherErr

--- a/v4/export/dump_test.go
+++ b/v4/export/dump_test.go
@@ -1,0 +1,111 @@
+package export
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testDumpSuite{})
+
+type testDumpSuite struct{}
+
+func (s *testDumpSuite) SetUpSuite(c *C) {
+	rand.Seed(time.Now().Unix())
+}
+
+func (s *testDumpSuite) TestDetectServerInfo(c *C) {
+	db, mock, err := sqlmock.New()
+	c.Assert(err, IsNil)
+	defer db.Close()
+
+	mkVer := makeServerVersion
+	data := [][]interface{}{
+		{"8.0.18", MySQLServerType, mkVer(8, 0, 18)},
+		{"10.4.10-MariaDB-1:10.4.10+maria~bionic", MariaDBServerType, mkVer(10, 4, 10)},
+		{"5.7.25-TiDB-v4.0.0-alpha-1263-g635f2e1af", TiDBServerType, mkVer(4, 0, 0)},
+		{"5.7.25-TiDB-v3.0.7-58-g6adce2367", TiDBServerType, mkVer(3, 0, 7)},
+	}
+
+	for _, datum := range data {
+		rows := sqlmock.NewRows([]string{"version"}).
+			AddRow(datum[0])
+		mock.ExpectQuery("SELECT version()").WillReturnRows(rows)
+
+		info, err := detectServerInfo(db)
+		c.Assert(err, IsNil)
+		c.Assert(info.ServerType, Equals, ServerType(datum[1].(int)))
+		c.Assert(info.ServerVersion, DeepEquals, datum[2].(*ServerVersion), Commentf("ServerType: %v", info.ServerType))
+		c.Assert(mock.ExpectationsWereMet(), IsNil)
+	}
+}
+
+func (s *testDumpSuite) TestBuildSelectAllQuery(c *C) {
+	db, mock, err := sqlmock.New()
+	c.Assert(err, IsNil)
+	defer db.Close()
+
+	const database, table = "test", "t"
+	getPkQuery := fmt.Sprintf(PrimaryKeyQuery, database, table)
+	const needSortedByPK = true
+	const noNeedSortedByPK = false
+	const isTiDB = true
+	const notTiDB = false
+	noPriKeyInTable := func() *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"COLUMN_NAME"})
+	}
+	hasPriKeyInTable := func() *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"COLUMN_NAME"}).AddRow("id")
+	}
+
+	plainQuery := "SELECT * FROM test.t"
+	orderByPkQuery := "SELECT * FROM test.t ORDER BY id"
+	orderByTiDBRowIDQuery := "SELECT * FROM test.t ORDER BY _tidb_rowid"
+
+	mockConf := DefaultConfig()
+	const shouldReturn = "placeholder"
+	cases := [][]interface{}{
+		// example:
+		// if we need to sort the output by primary key and
+		//    the server is TiDB and
+		//    there is no primary key in the testing table,
+		// then `buildSelectAllQuery` should return a "select * from t order by _tidb_rowid".
+		{1, needSortedByPK, isTiDB, noPriKeyInTable, shouldReturn, orderByTiDBRowIDQuery},
+		{2, needSortedByPK, isTiDB, hasPriKeyInTable, shouldReturn, orderByPkQuery},
+		{3, needSortedByPK, notTiDB, noPriKeyInTable, shouldReturn, plainQuery},
+		{4, needSortedByPK, notTiDB, hasPriKeyInTable, shouldReturn, orderByPkQuery},
+		{5, noNeedSortedByPK, isTiDB, noPriKeyInTable, shouldReturn, plainQuery},
+		{6, noNeedSortedByPK, isTiDB, hasPriKeyInTable, shouldReturn, plainQuery},
+		{7, noNeedSortedByPK, notTiDB, noPriKeyInTable, shouldReturn, plainQuery},
+		{8, noNeedSortedByPK, notTiDB, hasPriKeyInTable, shouldReturn, plainQuery},
+	}
+
+	for _, n := range cases {
+		tag, orderByPk, isTiDBType := n[0].(int), n[1].(bool), n[2].(bool)
+		rowsMaker, result := n[3].(func() *sqlmock.Rows), n[5].(string)
+
+		mockConf.SortByPk = orderByPk
+		if mockConf.SortByPk {
+			mock.ExpectQuery(getPkQuery).WillReturnRows(rowsMaker())
+		}
+		if isTiDBType {
+			mockConf.ServerInfo.ServerType = TiDBServerType
+		} else {
+			mockConf.ServerInfo.ServerType = randDBType([]ServerType{UnknownServerType, MySQLServerType, MariaDBServerType})
+		}
+
+		q, err := buildSelectAllQuery(mockConf, db, database, table)
+		cmt := Commentf("The test case number is: %d", tag)
+		c.Assert(err, IsNil, cmt)
+		c.Assert(q, Equals, result, cmt)
+		err = mock.ExpectationsWereMet()
+		c.Assert(err, IsNil, cmt)
+	}
+}
+
+func randDBType(ss []ServerType) ServerType {
+	return ss[rand.Intn(len(ss))]
+}


### PR DESCRIPTION
Support sorting output by primary key.
Use [DATA-DOG/go-sqlmock](https://github.com/DATA-DOG/go-sqlmock) to mock `database/sql` related types.