### PR TITLE
*: add integration test for dumping in given file size

### DIFF
--- a/cmd/dumpling/main.go
+++ b/cmd/dumpling/main.go
@@ -65,7 +65,7 @@ func init() {
 	flag.StringVar(&outputDir, "output", defaultOutputDir, "Output directory")
 	flag.StringVar(&outputDir, "o", defaultOutputDir, "Output directory")
 
-	flag.StringVar(&logLevel, "loglevel", "debug", "Log level: {debug|info|warn|error|dpanic|panic|fatal}")
+	flag.StringVar(&logLevel, "loglevel", "info", "Log level: {debug|info|warn|error|dpanic|panic|fatal}")
 
 	flag.StringVar(&consistency, "consistency", "auto", "Consistency level during dumping: {auto|none|flush|lock|snapshot}")
 
@@ -100,7 +100,7 @@ func main() {
 
 	err = export.Dump(conf)
 	if err != nil {
-		log.Zap().Error("dump failed", zap.String("error", err.Error()))
+		log.Zap().Error("dump failed", zap.Error(err))
 		os.Exit(1)
 	}
 	return

--- a/cmd/dumpling/main.go
+++ b/cmd/dumpling/main.go
@@ -65,7 +65,7 @@ func init() {
 	flag.StringVar(&outputDir, "output", defaultOutputDir, "Output directory")
 	flag.StringVar(&outputDir, "o", defaultOutputDir, "Output directory")
 
-	flag.StringVar(&logLevel, "loglevel", "info", "Log level: {debug|info|warn|error|dpanic|panic|fatal}")
+	flag.StringVar(&logLevel, "loglevel", "debug", "Log level: {debug|info|warn|error|dpanic|panic|fatal}")
 
 	flag.StringVar(&consistency, "consistency", "auto", "Consistency level during dumping: {auto|none|flush|lock|snapshot}")
 

--- a/tests/file_size/run.sh
+++ b/tests/file_size/run.sh
@@ -21,7 +21,7 @@ run_dumpling -filesize 200
 # the dumping result is expected to be:
 # 10 files for insertion(each conatins 10 records / 200 bytes)
 file_num=$(find "$DUMPLING_OUTPUT_DIR" -maxdepth 1 -iname "file_size.t.*.sql" | wc -l)
-if [ ! "$file_num" = 10 ]; then
+if [ "$file_num" -ne 10 ]; then
   echo "obtain file number: $file_num, but expect: 10" && exit 1
 fi
 

--- a/tests/file_size/run.sh
+++ b/tests/file_size/run.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -eu
+
+run_sql "drop database if exists file_size"
+run_sql "create database file_size"
+export DUMPLING_TEST_DATABASE=file_size
+run_sql "create table t (a varchar(255))"
+
+chars_20="1111_0000_1111_0000_"
+
+# insert 100 records, each occupies 20 bytes
+i=0; while [ $i -lt 100 ]; do
+  run_sql "insert into t values (\"$chars_20\")"
+  i=$(( i + 1 ))
+done
+
+# dumping with file size = 200 bytes
+run_dumpling -filesize 200
+
+# the dumping result is expected to be:
+# 10 files for insertion(each conatins 10 records / 200 bytes)
+file_num=$(find "$DUMPLING_OUTPUT_DIR" -maxdepth 1 -iname "file_size.t.*.sql" | wc -l)
+if [ ! "$file_num" = 10 ]; then
+  echo "obtain file number: $file_num, but expect: 10" && exit 1
+fi
+
+total_lines=$(find "$DUMPLING_OUTPUT_DIR" -maxdepth 1 -iname "file_size.t.*.sql" -print0 \
+ | xargs -0 cat | grep "$chars_20" -c)
+if [ ! "$total_lines" = 100 ]; then
+  echo "obtain record number: $total_lines, but expect: 100" && exit 1
+fi

--- a/v4/export/consistency_test.go
+++ b/v4/export/consistency_test.go
@@ -68,7 +68,7 @@ func (s *testConsistencySuite) TestConsistencyController(c *C) {
 		"db1": {"t1", "t2", "t3"},
 		"db2": {"t4"},
 	}
-	for i := 0; i < 4; i += 1 {
+	for i := 0; i < 4; i++ {
 		mock.ExpectExec("LOCK TABLES").WillReturnResult(resultOk)
 	}
 	mock.ExpectExec("UNLOCK TABLES").WillReturnResult(resultOk)

--- a/v4/export/ir_impl.go
+++ b/v4/export/ir_impl.go
@@ -48,7 +48,7 @@ func (s *sizedRowIter) Next(row RowReceiver) error {
 }
 
 func (s *sizedRowIter) HasNext() bool {
-	if s.currentSize > s.sizeLimit {
+	if s.currentSize >= s.sizeLimit {
 		return false
 	}
 	return s.rowIter.HasNext()
@@ -117,12 +117,16 @@ func (td *tableData) SpecialComments() StringIter {
 
 type tableDataChunks struct {
 	TableDataIR
+	rows      SQLRowIter
 	sizeLimit uint64
 }
 
 func (t *tableDataChunks) Rows() SQLRowIter {
+	if t.rows == nil {
+		t.rows = t.TableDataIR.Rows()
+	}
 	return &sizedRowIter{
-		rowIter:   t.Rows(),
+		rowIter:   t.rows,
 		sizeLimit: t.sizeLimit,
 	}
 }

--- a/v4/export/ir_impl_test.go
+++ b/v4/export/ir_impl_test.go
@@ -26,11 +26,11 @@ func (s *simpleRowReceiver) BindAddress(args []interface{}) {
 }
 
 func (s *simpleRowReceiver) ReportSize() uint64 {
-	sum := 0
+	var sum uint64
 	for _, datum := range s.data {
-		sum += len(datum)
+		sum += uint64(len(datum))
 	}
-	return uint64(sum)
+	return sum
 }
 
 func (s *testIRImplSuite) TestRowIter(c *C) {
@@ -47,7 +47,7 @@ func (s *testIRImplSuite) TestRowIter(c *C) {
 	c.Assert(err, IsNil)
 
 	iter := newRowIter(rows, 1)
-	for i := 0; i < 100; i += 1 {
+	for i := 0; i < 100; i++ {
 		c.Assert(iter.HasNext(), IsTrue)
 	}
 	res := newSimpleRowReceiver(1)
@@ -68,10 +68,10 @@ func (s *testIRImplSuite) TestSizedRowIter(c *C) {
 	c.Assert(err, IsNil)
 	defer db.Close()
 
-	twentyBytes := repeat("x", 20)
-	thirtyBytes := repeat("x", 30)
+	twentyBytes := strings.Repeat("x", 20)
+	thirtyBytes := strings.Repeat("x", 30)
 	expectedRows := mock.NewRows([]string{"a", "b"})
-	for i := 0; i < 10; i += 1 {
+	for i := 0; i < 10; i++ {
 		expectedRows.AddRow(twentyBytes, thirtyBytes)
 	}
 	mock.ExpectQuery("SELECT a, b FROM t").WillReturnRows(expectedRows)
@@ -83,7 +83,7 @@ func (s *testIRImplSuite) TestSizedRowIter(c *C) {
 		sizeLimit: 200,
 	}
 	res := newSimpleRowReceiver(2)
-	for i := 0; i < 200/50; i += 1 {
+	for i := 0; i < 200/50; i++ {
 		c.Assert(sizedRowIter.HasNext(), IsTrue)
 		err := sizedRowIter.Next(res)
 		c.Assert(err, IsNil)
@@ -92,12 +92,4 @@ func (s *testIRImplSuite) TestSizedRowIter(c *C) {
 	c.Assert(sizedRowIter.HasNext(), IsFalse)
 	rows.Close()
 	c.Assert(sizedRowIter.Next(res), NotNil)
-}
-
-func repeat(x string, size int) string {
-	var sb strings.Builder
-	for i := 0; i < size; i += 1 {
-		sb.WriteString(x)
-	}
-	return sb.String()
 }

--- a/v4/export/ir_impl_test.go
+++ b/v4/export/ir_impl_test.go
@@ -1,6 +1,8 @@
 package export
 
 import (
+	"strings"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	. "github.com/pingcap/check"
 )
@@ -10,15 +12,25 @@ var _ = Suite(&testIRImplSuite{})
 type testIRImplSuite struct{}
 
 type simpleRowReceiver struct {
-	data string
+	data []string
 }
 
-func (s *simpleRowReceiver) BindAddress(arg []interface{}) {
-	arg[0] = &s.data
+func newSimpleRowReceiver(length int) *simpleRowReceiver {
+	return &simpleRowReceiver{data: make([]string, length)}
+}
+
+func (s *simpleRowReceiver) BindAddress(args []interface{}) {
+	for i := range args {
+		args[i] = &s.data[i]
+	}
 }
 
 func (s *simpleRowReceiver) ReportSize() uint64 {
-	panic("not implement")
+	sum := 0
+	for _, datum := range s.data {
+		sum += len(datum)
+	}
+	return uint64(sum)
 }
 
 func (s *testIRImplSuite) TestRowIter(c *C) {
@@ -38,15 +50,54 @@ func (s *testIRImplSuite) TestRowIter(c *C) {
 	for i := 0; i < 100; i += 1 {
 		c.Assert(iter.HasNext(), IsTrue)
 	}
-	res := &simpleRowReceiver{}
+	res := newSimpleRowReceiver(1)
 	c.Assert(iter.Next(res), IsNil)
-	c.Assert(res.data, Equals, "1")
+	c.Assert(res.data, DeepEquals, []string{"1"})
 	c.Assert(iter.HasNext(), IsTrue)
 	c.Assert(iter.HasNext(), IsTrue)
 	c.Assert(iter.Next(res), IsNil)
-	c.Assert(res.data, Equals, "2")
+	c.Assert(res.data, DeepEquals, []string{"2"})
 	c.Assert(iter.HasNext(), IsTrue)
 	c.Assert(iter.Next(res), IsNil)
-	c.Assert(res.data, Equals, "3")
+	c.Assert(res.data, DeepEquals, []string{"3"})
 	c.Assert(iter.HasNext(), IsFalse)
+}
+
+func (s *testIRImplSuite) TestSizedRowIter(c *C) {
+	db, mock, err := sqlmock.New()
+	c.Assert(err, IsNil)
+	defer db.Close()
+
+	twentyBytes := repeat("x", 20)
+	thirtyBytes := repeat("x", 30)
+	expectedRows := mock.NewRows([]string{"a", "b"})
+	for i := 0; i < 10; i += 1 {
+		expectedRows.AddRow(twentyBytes, thirtyBytes)
+	}
+	mock.ExpectQuery("SELECT a, b FROM t").WillReturnRows(expectedRows)
+	rows, err := db.Query("SELECT a, b FROM t")
+	c.Assert(err, IsNil)
+
+	sizedRowIter := sizedRowIter{
+		rowIter:   newRowIter(rows, 2),
+		sizeLimit: 200,
+	}
+	res := newSimpleRowReceiver(2)
+	for i := 0; i < 200/50; i += 1 {
+		c.Assert(sizedRowIter.HasNext(), IsTrue)
+		err := sizedRowIter.Next(res)
+		c.Assert(err, IsNil)
+	}
+	c.Assert(sizedRowIter.HasNext(), IsFalse)
+	c.Assert(sizedRowIter.HasNext(), IsFalse)
+	rows.Close()
+	c.Assert(sizedRowIter.Next(res), NotNil)
+}
+
+func repeat(x string, size int) string {
+	var sb strings.Builder
+	for i := 0; i < size; i += 1 {
+		sb.WriteString(x)
+	}
+	return sb.String()
 }

--- a/v4/export/prepare_test.go
+++ b/v4/export/prepare_test.go
@@ -1,0 +1,71 @@
+package export
+
+import (
+	"fmt"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testPrepareSuite{})
+
+type testPrepareSuite struct{}
+
+func (s *testPrepareSuite) TestPrepareDumpingDatabases(c *C) {
+	db, mock, err := sqlmock.New()
+	c.Assert(err, IsNil)
+	defer db.Close()
+
+	conf := DefaultConfig()
+	conf.Database = "db1,db2,db3"
+	result, err := prepareDumpingDatabases(conf, db)
+	c.Assert(err, IsNil)
+	c.Assert(result, DeepEquals, []string{"db1", "db2", "db3"})
+
+	conf.Database = ""
+	rows := sqlmock.NewRows([]string{"Database"}).
+		AddRow("db1").
+		AddRow("db2")
+	mock.ExpectQuery("SHOW DATABASES").WillReturnRows(rows)
+	result, err = prepareDumpingDatabases(conf, db)
+	c.Assert(err, IsNil)
+	c.Assert(result, DeepEquals, []string{"db1", "db2"})
+
+	mock.ExpectQuery("SHOW DATABASES").WillReturnError(fmt.Errorf("err"))
+	_, err = prepareDumpingDatabases(conf, db)
+	c.Assert(err, NotNil)
+	c.Assert(mock.ExpectationsWereMet(), IsNil)
+}
+
+func (s *testPrepareSuite) TestListAllTables(c *C) {
+	db, mock, err := sqlmock.New()
+	c.Assert(err, IsNil)
+	defer db.Close()
+
+	resultOk := sqlmock.NewResult(0, 0)
+	data := map[databaseName][]tableName{
+		"db1": {"t1", "t2"},
+		"db2": {"t3", "t4", "t5"},
+	}
+
+	var dbNames []databaseName
+	for dbName, tbNames := range data {
+		dbNames = append(dbNames, dbName)
+		mock.ExpectExec("USE .").WillReturnResult(resultOk)
+		rows := sqlmock.NewRows([]string{"Tables_in_xx"})
+		for _, name := range tbNames {
+			rows.AddRow(name)
+		}
+		mock.ExpectQuery("SHOW TABLES").WillReturnRows(rows)
+	}
+
+	tables, err := listAllTables(db, dbNames)
+	c.Assert(err, IsNil)
+
+	for d, t := range tables {
+		expectedTbs, ok := data[d]
+		c.Assert(ok, IsTrue)
+		c.Assert(t, DeepEquals, expectedTbs)
+	}
+	c.Assert(mock.ExpectationsWereMet(), IsNil)
+}

--- a/v4/export/writer.go
+++ b/v4/export/writer.go
@@ -3,10 +3,11 @@ package export
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path"
-	"sync"
+
+	"github.com/pingcap/dumpling/v4/log"
+	"go.uber.org/zap"
 )
 
 type Writer interface {
@@ -25,91 +26,58 @@ func NewSimpleWriter(config *Config) (Writer, error) {
 }
 
 func (f *SimpleWriter) WriteDatabaseMeta(ctx context.Context, db, createSQL string) error {
-	fileName := path.Join(f.cfg.OutputDirPath, fmt.Sprintf("%s-schema-create.sql", db))
-	fsStringWriter := NewFileSystemStringWriter(fileName, false)
-	meta := &metaData{
-		target:  db,
-		metaSQL: createSQL,
-	}
-	return WriteMeta(meta, fsStringWriter)
+	fileName := fmt.Sprintf("%s-schema-create.sql", db)
+	filePath := path.Join(f.cfg.OutputDirPath, fileName)
+	return writeMetaToFile(db, createSQL, filePath)
 }
 
 func (f *SimpleWriter) WriteTableMeta(ctx context.Context, db, table, createSQL string) error {
-	fileName := path.Join(f.cfg.OutputDirPath, fmt.Sprintf("%s.%s-schema.sql", db, table))
-	fsStringWriter := NewFileSystemStringWriter(fileName, false)
-	meta := &metaData{
-		target:  table,
-		metaSQL: createSQL,
-	}
-	return WriteMeta(meta, fsStringWriter)
+	fileName := fmt.Sprintf("%s.%s-schema.sql", db, table)
+	filePath := path.Join(f.cfg.OutputDirPath, fileName)
+	return writeMetaToFile(db, createSQL, filePath)
 }
 
 func (f *SimpleWriter) WriteTableData(ctx context.Context, ir TableDataIR) error {
+	log.Zap().Debug("start dumping table...", zap.String("table", ir.TableName()))
 	if f.cfg.FileSize == UnspecifiedSize {
 		fileName := path.Join(f.cfg.OutputDirPath, fmt.Sprintf("%s.%s.sql", ir.DatabaseName(), ir.TableName()))
-		fsStringWriter := NewFileSystemStringWriter(fileName, true)
-		return WriteInsert(ir, fsStringWriter)
+		fileWriter, tearDown := buildLazyFileWriter(fileName)
+		defer tearDown()
+		return WriteInsert(ir, fileWriter)
 	}
 
-	ir = splitTableDataIntoChunks(ir, f.cfg.FileSize)
-	for chunkCount := 0; ; /* loop */ chunkCount += 1 {
-		fileName := path.Join(f.cfg.OutputDirPath, fmt.Sprintf("%s.%s.%3d.sql", ir.DatabaseName(), ir.TableName(), chunkCount))
-		fsStringWriter := newInterceptStringWriter(NewFileSystemStringWriter(fileName, true))
-		err := WriteInsert(ir, fsStringWriter)
+	chunks := splitTableDataIntoChunks(ir, f.cfg.FileSize)
+	chunkCount := 0
+	for {
+		fileName := fmt.Sprintf("%s.%s.%d.sql", ir.DatabaseName(), ir.TableName(), chunkCount)
+		filePath := path.Join(f.cfg.OutputDirPath, fileName)
+		fileWriter, tearDown := buildLazyFileWriter(filePath)
+		intWriter := &InterceptStringWriter{StringWriter: fileWriter}
+		err := WriteInsert(chunks, intWriter)
+		tearDown()
 		if err != nil {
 			return err
 		}
-		if fsStringWriter.writeNothingYet {
+
+		if !intWriter.SomethingIsWritten {
 			break
 		}
+		chunkCount += 1
 	}
+	log.Zap().Debug("dumping table successfully",
+		zap.String("table", ir.TableName()))
 	return nil
 }
 
-type FileSystemStringWriter struct {
-	path string
-
-	file *os.File
-	once sync.Once
-	err  error
-}
-
-func (w *FileSystemStringWriter) initFileHandle() {
-	w.file, w.err = os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY, 0755)
-}
-
-func (w *FileSystemStringWriter) WriteString(str string) (int, error) {
-	if w.err != nil {
-		return 0, w.err
+func writeMetaToFile(target, metaSQL, path string) error {
+	fileWriter, tearDown, err := buildFileWriter(path)
+	if err != nil {
+		return err
 	}
-	w.once.Do(w.initFileHandle)
-	return w.file.WriteString(str)
-}
+	defer tearDown()
 
-func NewFileSystemStringWriter(path string, lazyHandleCreation bool) *FileSystemStringWriter {
-	w := &FileSystemStringWriter{path: path}
-	if !lazyHandleCreation {
-		w.once.Do(w.initFileHandle)
-	}
-	return w
-}
-
-type interceptStringWriter struct {
-	sw              io.StringWriter
-	writeNothingYet bool
-}
-
-func (i *interceptStringWriter) WriteString(str string) (int, error) {
-	writtenBytes, err := i.sw.WriteString(str)
-	if writtenBytes != 0 {
-		i.writeNothingYet = false
-	}
-	return writtenBytes, err
-}
-
-func newInterceptStringWriter(sw io.StringWriter) *interceptStringWriter {
-	return &interceptStringWriter{
-		sw:              sw,
-		writeNothingYet: true,
-	}
+	return WriteMeta(&metaData{
+		target:  target,
+		metaSQL: metaSQL,
+	}, fileWriter)
 }

--- a/v4/export/writer_util.go
+++ b/v4/export/writer_util.go
@@ -167,7 +167,9 @@ type InterceptStringWriter struct {
 }
 
 func (w *InterceptStringWriter) WriteString(str string) (int, error) {
-	w.SomethingIsWritten = true
+	if len(str) > 0 {
+		w.SomethingIsWritten = true
+	}
 	return w.StringWriter.WriteString(str)
 }
 

--- a/v4/export/writer_util.go
+++ b/v4/export/writer_util.go
@@ -52,7 +52,7 @@ func WriteInsert(tblIR TableDataIR, w io.StringWriter) error {
 	for rowIter.HasNext() {
 		row := MakeRowReceiver(tblIR.ColumnTypes())
 		if err := rowIter.Next(row); err != nil {
-			log.Zap().Error("scanning from sql.Row failed", zap.String("error", err.Error()))
+			log.Zap().Error("scanning from sql.Row failed", zap.Error(err))
 			return err
 		}
 
@@ -82,7 +82,7 @@ func write(writer io.StringWriter, str string) error {
 	if err != nil {
 		log.Zap().Error("writing failed",
 			zap.String("string", str),
-			zap.String("error", err.Error()))
+			zap.Error(err))
 	}
 	return err
 }
@@ -92,7 +92,7 @@ func buildFileWriter(path string) (io.StringWriter, func(), error) {
 	if err != nil {
 		log.Zap().Error("open file failed",
 			zap.String("path", path),
-			zap.String("error", err.Error()))
+			zap.Error(err))
 		return nil, nil, err
 	}
 	log.Zap().Debug("opened file", zap.String("path", path))
@@ -103,7 +103,9 @@ func buildFileWriter(path string) (io.StringWriter, func(), error) {
 		if err == nil {
 			return
 		}
-		log.Zap().Error("close file failed", zap.String("path", path))
+		log.Zap().Error("close file failed",
+			zap.String("path", path),
+			zap.Error(err))
 	}
 	return buf, tearDownRoutine, nil
 }
@@ -118,7 +120,7 @@ func buildLazyFileWriter(path string) (io.StringWriter, func()) {
 		if err != nil {
 			log.Zap().Error("open file failed",
 				zap.String("path", path),
-				zap.String("error", err.Error()))
+				zap.Error(err))
 		}
 		log.Zap().Debug("opened file", zap.String("path", path))
 		buf = bufio.NewWriter(file)

--- a/v4/export/writer_util.go
+++ b/v4/export/writer_util.go
@@ -1,9 +1,12 @@
 package export
 
 import (
+	"bufio"
 	"fmt"
 	"io"
+	"os"
 	"strings"
+	"sync"
 
 	"github.com/pingcap/dumpling/v4/log"
 	"go.uber.org/zap"
@@ -33,7 +36,6 @@ func WriteInsert(tblIR TableDataIR, w io.StringWriter) error {
 		return nil
 	}
 
-	log.Zap().Debug("start dumping for table", zap.String("table", tblIR.TableName()))
 	specCmtIter := tblIR.SpecialComments()
 	for specCmtIter.HasNext() {
 		if err := write(w, fmt.Sprintf("%s\n", specCmtIter.Next())); err != nil {
@@ -46,6 +48,7 @@ func WriteInsert(tblIR TableDataIR, w io.StringWriter) error {
 		return err
 	}
 
+	counter := 0
 	for rowIter.HasNext() {
 		row := MakeRowReceiver(tblIR.ColumnTypes())
 		if err := rowIter.Next(row); err != nil {
@@ -56,6 +59,7 @@ func WriteInsert(tblIR TableDataIR, w io.StringWriter) error {
 		if err := write(w, row.ToString()); err != nil {
 			return err
 		}
+		counter += 1
 
 		var splitter string
 		if rowIter.HasNext() {
@@ -67,7 +71,9 @@ func WriteInsert(tblIR TableDataIR, w io.StringWriter) error {
 			return err
 		}
 	}
-	log.Zap().Debug("finish dumping for table", zap.String("table", tblIR.TableName()))
+	log.Zap().Debug("dumping table",
+		zap.String("table", tblIR.TableName()),
+		zap.Int("record counts", counter))
 	return nil
 }
 
@@ -79,6 +85,88 @@ func write(writer io.StringWriter, str string) error {
 			zap.String("error", err.Error()))
 	}
 	return err
+}
+
+func buildFileWriter(path string) (io.StringWriter, func(), error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	if err != nil {
+		log.Zap().Error("open file failed",
+			zap.String("path", path),
+			zap.String("error", err.Error()))
+		return nil, nil, err
+	}
+	log.Zap().Debug("opened file", zap.String("path", path))
+	buf := bufio.NewWriter(file)
+	tearDownRoutine := func() {
+		_ = buf.Flush()
+		err := file.Close()
+		if err == nil {
+			return
+		}
+		log.Zap().Error("close file failed", zap.String("path", path))
+	}
+	return buf, tearDownRoutine, nil
+}
+
+func buildLazyFileWriter(path string) (io.StringWriter, func()) {
+	var file *os.File
+	var buf *bufio.Writer
+	lazyStringWriter := &LazyStringWriter{}
+	initRoutine := func() error {
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+		file = f
+		if err != nil {
+			log.Zap().Error("open file failed",
+				zap.String("path", path),
+				zap.String("error", err.Error()))
+		}
+		log.Zap().Debug("opened file", zap.String("path", path))
+		buf = bufio.NewWriter(file)
+		lazyStringWriter.StringWriter = buf
+		return err
+	}
+	lazyStringWriter.initRoutine = initRoutine
+
+	tearDownRoutine := func() {
+		if file == nil {
+			return
+		}
+		log.Zap().Debug("tear down lazy file writer...")
+		_ = buf.Flush()
+		err := file.Close()
+		if err == nil {
+			return
+		}
+		log.Zap().Error("close file failed", zap.String("path", path))
+	}
+	return lazyStringWriter, tearDownRoutine
+}
+
+type LazyStringWriter struct {
+	initRoutine func() error
+	sync.Once
+	io.StringWriter
+	err error
+}
+
+func (l *LazyStringWriter) WriteString(str string) (int, error) {
+	l.Do(func() { l.err = l.initRoutine() })
+	if l.err != nil {
+		return 0, fmt.Errorf("open file error: %s", l.err.Error())
+	}
+	return l.StringWriter.WriteString(str)
+}
+
+// InterceptStringWriter is an interceptor of io.StringWriter,
+// tracking whether a StringWriter has written something.
+type InterceptStringWriter struct {
+	io.StringWriter
+	SomethingIsWritten bool
+}
+
+func (w *InterceptStringWriter) WriteString(str string) (int, error) {
+	w.SomethingIsWritten = true
+	return w.StringWriter.WriteString(str)
 }
 
 func wrapBackTicks(identifier string) string {


### PR DESCRIPTION
Changes:

- add integration tests: SQL files are split into size close to the given configuration.
- fix the one-offset bug in `tableDataChunks.Rows()`: calling it multiple times should not push forward its inner `*sql.Rows`.
- add test for `sizedRowIter`.
- add test for `prepareDumpingDatabases`.
- rewrite `SimpleWriter`.