### PR TITLE
Adjust CLI parameters to make them the same as mydumper

### DIFF
--- a/cmd/dumpling/main.go
+++ b/cmd/dumpling/main.go
@@ -18,8 +18,10 @@ import (
 	"fmt"
 	_ "net/http/pprof"
 	"os"
+	"strconv"
 	"time"
 
+	"github.com/docker/go-units"
 	"github.com/pingcap/dumpling/v4/cli"
 	"github.com/pingcap/dumpling/v4/export"
 	filter "github.com/pingcap/tidb-tools/pkg/table-filter"
@@ -34,7 +36,7 @@ var (
 	password      string
 	threads       int
 	outputDir     string
-	fileSize      uint64
+	fileSizeStr   string
 	statementSize uint64
 	logLevel      string
 	logFile       string
@@ -71,13 +73,13 @@ func main() {
 	pflag.ErrHelp = errors.New("")
 
 	pflag.StringSliceVarP(&databases, "database", "B", nil, "Databases to dump")
-	pflag.StringVarP(&host, "host", "H", "127.0.0.1", "The host to connect to")
+	pflag.StringVarP(&host, "host", "h", "127.0.0.1", "The host to connect to")
 	pflag.StringVarP(&user, "user", "u", "root", "Username with privileges to run the dump")
 	pflag.IntVarP(&port, "port", "P", 4000, "TCP/IP port to connect to")
 	pflag.StringVarP(&password, "password", "p", "", "User password")
 	pflag.IntVarP(&threads, "threads", "t", 4, "Number of goroutines to use, default 4")
-	pflag.Uint64VarP(&fileSize, "filesize", "F", export.UnspecifiedSize, "The approximate size of output file")
-	pflag.Uint64VarP(&statementSize, "statement-size", "S", export.UnspecifiedSize, "Attempted size of INSERT statement in bytes")
+	pflag.StringVarP(&fileSizeStr, "filesize", "F", "", "The approximate size of output file")
+	pflag.Uint64VarP(&statementSize, "statement-size", "s", export.UnspecifiedSize, "Attempted size of INSERT statement in bytes")
 	pflag.StringVarP(&outputDir, "output", "o", defaultOutputDir, "Output directory")
 	pflag.StringVar(&logLevel, "loglevel", "info", "Log level: {debug|info|warn|error|dpanic|panic|fatal}")
 	pflag.StringVarP(&logFile, "logfile", "L", "", "Log file `path`, leave empty to write to console")
@@ -94,7 +96,7 @@ func main() {
 	pflag.BoolVarP(&noSchemas, "no-schemas", "m", false, "Do not dump table schemas with the data")
 	pflag.BoolVarP(&noData, "no-data", "d", false, "Do not dump table data")
 	pflag.StringVar(&csvNullValue, "csv-null-value", "\\N", "The null value used when export to csv")
-	pflag.StringVarP(&sql, "sql", "s", "", "Dump data with given sql")
+	pflag.StringVarP(&sql, "sql", "S", "", "Dump data with given sql")
 	pflag.StringArrayVarP(&filters, "filter", "f", []string{"*.*"}, "filter to select which tables to dump")
 	pflag.BoolVar(&caseSensitive, "case-sensitive", false, "whether the filter should be case-sensitive")
 
@@ -115,6 +117,19 @@ func main() {
 	}
 	if !caseSensitive {
 		tableFilter = filter.CaseInsensitive(tableFilter)
+	}
+
+	var fileSize uint64
+	if len(fileSizeStr) == 0 {
+		fileSize = export.UnspecifiedSize
+	} else if fileSizeMB, err := strconv.ParseUint(fileSizeStr, 10, 64); err == nil {
+		fmt.Printf("Warning: -F without unit is not recommended, try using `-F '%dMiB'` in the future\n", fileSizeMB)
+		fileSize = fileSizeMB * units.MiB
+	} else if size, err := units.RAMInBytes(fileSizeStr); err == nil {
+		fileSize = uint64(size)
+	} else {
+		fmt.Printf("failed to parse filesize (-F '%s')\n", fileSizeStr)
+		os.Exit(2)
 	}
 
 	conf := export.DefaultConfig()

--- a/docs/cn/user-guide.md
+++ b/docs/cn/user-guide.md
@@ -11,7 +11,7 @@
 | --------| --- |
 | -B 或 --database | 导出指定数据库 |
 | -f 或 --filter | 导出能匹配模式的表，语法可参考 [table-filter](https://github.com/pingcap/tidb-tools/blob/master/pkg/table-filter/README.md)（只有英文版） |
-| -H 或 --host| 链接节点地址(默认 "127.0.0.1")|
+| -h 或 --host| 链接节点地址(默认 "127.0.0.1")|
 | -t 或 --threads | 备份并发线程数|
 | -r 或 --rows |将 table 划分成 row 行数据，一般针对大表操作并发生成多个文件。|
 | --loglevel | 日志级别 {debug,info,warn,error,dpanic,panic,fatal} (默认 "info") |
@@ -20,7 +20,7 @@
 | -W 或 --no-views| 不导出 view, 默认 true |
 | -m 或 --no-schemas | 不导出 schema , 只导出数据 |
 | -s 或--statement-size | 控制 Insert Statement 的大小，单位 bytes |
-| -F 或 --filesize | 将 table 数据划分出来的文件大小, 单位 bytes |
+| -F 或 --filesize | 将 table 数据划分出来的文件大小, 需指明单位 (如 `128B`, `64KiB`, `32MiB`, `1.5GiB`) |
 | --filetype| 导出文件类型 csv/sql (默认 sql) |
 | -o 或 --output | 设置导出文件路径 |
 | --consistency | flush: dump 前用 FTWRL <br> snapshot: 通过 tso 指定 dump 位置 <br> lock: 对需要 dump 的所有表执行 lock tables read <br> none: 不加锁 dump，无法保证一致性 <br> auto: MySQL flush, TiDB snapshot|

--- a/docs/en/user-guide.md
+++ b/docs/en/user-guide.md
@@ -11,7 +11,7 @@ The following table lists the major parameters of Dumpling.
 | --------| --- |
 | -B or --database | Dump the specified databases. |
 | -f or --filter | Dump only the tables matching the patterns. See [table-filter](https://github.com/pingcap/tidb-tools/blob/master/pkg/table-filter/README.md) for syntax. |
-| -H or --host | Host to connect to. (default: `127.0.0.1`) |
+| -h or --host | Host to connect to. (default: `127.0.0.1`) |
 | -t or --threads | Number of threads for concurrent backup. |
 | -r or --rows | Split table into multiple files by number of rows. This allows Dumpling to generate multiple files concurrently. (default: unlimited) |
 | --loglevel | Log level. {debug, info, warn, error, dpanic, panic, fatal}. (default: `info`) |
@@ -20,7 +20,7 @@ The following table lists the major parameters of Dumpling.
 | -W or --no-views | Don't dump views. (default: `true`) |
 | -m or --no-schemas | Don't dump schemas, dump data only. |
 | -s or --statement-size | Control the size of Insert Statement. Unit: byte. |
-| -F or --filesize | The approximate size of the output file. Unit: byte. |
+| -F or --filesize | The approximate size of the output file. The unit should be explicitly provided (such as `128B`, `64KiB`, `32MiB`, `1.5GiB`) |
 | --filetype| The type of dump file. (sql/csv, default "sql")           |
 | -o or --output | Output directory. The default value is based on time. |
 | --consistency | Which consistency control to use (default `auto`):<br>`flush`: Use FTWRL (flush tables with read lock)<br>`snapshot`: use a snapshot at a given timestamp<br>`lock`: execute lock tables read for all tables that need to be locked <br>`none`: dump without locking. It cannot guarantee consistency <br>`auto`: `flush` on MySQL, `snapshot` on TiDB |

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/DATA-DOG/go-sqlmock v1.4.1
 	github.com/coreos/go-semver v0.3.0
+	github.com/docker/go-units v0.4.0
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
+github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=

--- a/tests/_utils/run_dumpling
+++ b/tests/_utils/run_dumpling
@@ -4,6 +4,6 @@ set -e
 
 echo "[$(date)] Executing bin/dumpling..."
 
-bin/dumpling -u "$DUMPLING_TEST_USER" -H "$DUMPLING_TEST_HOST" \
+bin/dumpling -u "$DUMPLING_TEST_USER" -h "$DUMPLING_TEST_HOST" \
     -P "$DUMPLING_TEST_PORT" -B "$DUMPLING_TEST_DATABASE" \
     -p "$DUMPLING_TEST_PASSWORD" -o "$DUMPLING_OUTPUT_DIR" "$@"

--- a/tests/file_size/run.sh
+++ b/tests/file_size/run.sh
@@ -13,7 +13,7 @@ chars_20="1111_0000_1111_0000_"
 run_sql "insert into t values $(seq -s, 100 | sed 's/,*$//g' | sed "s/[0-9]*/('$chars_20')/g");"
 
 # dumping with file size = 200 bytes
-run_dumpling -F 200
+run_dumpling -F 200B
 
 # the dumping result is expected to be:
 # 10 files for insertion(each conatins 10 records / 200 bytes)

--- a/tests/no_table_and_db_name/run.sh
+++ b/tests/no_table_and_db_name/run.sh
@@ -21,7 +21,7 @@ chars_20="1111_0000_1111_0000_"
 run_sql "insert into t values $(seq -s, 100 | sed 's/,*$//g' | sed "s/[0-9]*/('$chars_20')/g");"
 
 # dumping with file size = 200 bytes
-run_dumpling -F 200 --filetype csv --sql "select * from $TEST_NAME.t"
+run_dumpling -F 200B --filetype csv --sql "select * from $TEST_NAME.t"
 
 assert [ $( ls -lh $DUMPLING_OUTPUT_DIR | grep -e ".csv$" | wc -l ) -eq 10 ]
 


### PR DESCRIPTION
Fix #85, fix the `-F` part of #76.

* `-F`'s unit is now MiB rather than Bytes. Additionally, allow explicitly setting the unit (e.g. `-F 64MiB`).
* `--statement-size` is now `-s` rather than `-S`.
* `--sql` is now `-S` rather than `-s` (cc @AndrewDi)
* `--host` is now `-h` rather than `-H`
* Added `-T`

