### PR TITLE
refine output error stack info

### DIFF
--- a/cmd/dumpling/main.go
+++ b/cmd/dumpling/main.go
@@ -25,8 +25,10 @@ import (
 	"github.com/docker/go-units"
 	"github.com/pingcap/dumpling/v4/cli"
 	"github.com/pingcap/dumpling/v4/export"
+	"github.com/pingcap/log"
 	filter "github.com/pingcap/tidb-tools/pkg/table-filter"
 	"github.com/spf13/pflag"
+	"go.uber.org/zap"
 )
 
 var (
@@ -164,7 +166,8 @@ func main() {
 
 	err = export.Dump(conf)
 	if err != nil {
-		fmt.Printf("dump failed: %s\n", err.Error())
+		log.Error("dump failed error stack info", zap.Error(err))
+		fmt.Printf("\ndump failed: %s\n", err.Error())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Fix #69.

1. avoid adding duplicate stack info
2. save stack info into log. Print simple info to the users. example:

```bash
./bin/dumpling 
Release version: 
Git commit hash: e5fd9c6124696e09626cd662fa7fc897716da4de
Git branch:      refineErrorStack
Build timestamp: 2020-06-02 07:39:27Z
Go version:      go version go1.13.4 darwin/amd64

[2020/06/02 15:39:35.029 +08:00] [ERROR] [main.go:169] ["dump failed error stack info"] [error="dial tcp 127.0.0.1:4000: connect: connection refused"] [errorVerbose="err = dial tcp 127.0.0.1:4000: connect: connection refused\ngoroutine 1 [running]:\nruntime/debug.Stack(0x1610b20, 0xc000138370, 0x16115a0)\n\t/usr/local/go/src/runtime/debug/stack.go:24 +0x9d\ngithub.com/pingcap/dumpling/v4/export.withStack(0x1610b20, 0xc000138370, 0xc0000bc070, 0x1562f77)\n\t/Users/chauncy/code/goPath/src/github.com/pingcap/dumpling/v4/export/error.go:59 +0x8d\ngithub.com/pingcap/dumpling/v4/export.simpleQueryWithArgs(0xc00019a000, 0xc00010fa48, 0x1562f77, 0x10, 0x0, 0x0, 0x0, 0xc00011e080, 0x0)\n\t/Users/chauncy/code/goPath/src/github.com/pingcap/dumpling/v4/export/sql.go:364 +0x168\ngithub.com/pingcap/dumpling/v4/export.simpleQuery(...)\n\t/Users/chauncy/code/goPath/src/github.com/pingcap/dumpling/v4/export/sql.go:358\ngithub.com/pingcap/dumpling/v4/export.SelectVersion(0xc00019a000, 0x2a, 0x102f7ba, 0xc00014a1e0, 0xc000122340)\n\t/Users/chauncy/code/goPath/src/github.com/pingcap/dumpling/v4/export/sql.go:94 +0x90\ngithub.com/pingcap/dumpling/v4/export.detectServerInfo(0xc00019a000, 0x5, 0xc00014a1e0, 0x2a, 0xc00019a000)\n\t/Users/chauncy/code/goPath/src/github.com/pingcap/dumpling/v4/export/prepare.go:34 +0x2f\ngithub.com/pingcap/dumpling/v4/export.Dump(0xc000190000, 0x0, 0x0)\n\t/Users/chauncy/code/goPath/src/github.com/pingcap/dumpling/v4/export/dump.go:35 +0x2cb\nmain.main()\n\t/Users/chauncy/code/goPath/src/github.com/pingcap/dumpling/cmd/dumpling/main.go:167 +0x105a\n"] [stack="github.com/pingcap/log.Error\n\t/Users/chauncy/code/goPath/pkg/mod/github.com/pingcap/log@v0.0.0-20200511115504-543df19646ad/global.go:42\nmain.main\n\t/Users/chauncy/code/goPath/src/github.com/pingcap/dumpling/cmd/dumpling/main.go:169\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:203"]

dump failed: dial tcp 127.0.0.1:4000: connect: connection refused

```