### PR TITLE
fix unique key null bug

### DIFF
--- a/tests/null_unique_index/run.sh
+++ b/tests/null_unique_index/run.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -eu
+cur=$(cd `dirname $0`; pwd)
+
+DB_NAME="null_unique_key"
+
+# drop database on mysql
+run_sql "drop database if exists \`$DB_NAME\`;"
+
+# build data on mysql
+run_sql "create database \`$DB_NAME\`;"
+run_sql "create table \`$DB_NAME\`.\`t\` (a int unique key, b int);"
+run_sql "insert into \`$DB_NAME\`.\`t\` values (1, 2), (NULL, 1);"
+
+
+# dumping
+export DUMPLING_TEST_DATABASE=$DB_NAME
+run_dumpling -r 1
+
+data="NULL"
+cnt=$(sed "s/$data/$data\n/g" $DUMPLING_OUTPUT_DIR/$DB_NAME.t.1.sql | grep -c "$data") || true
+[ $cnt = 1 ]
+

--- a/v4/export/ir_impl.go
+++ b/v4/export/ir_impl.go
@@ -323,15 +323,19 @@ func splitTableDataIntoChunks(
 	}
 
 	chunkIndex := 0
+	nullValueCondition := fmt.Sprintf("`%s` IS NULL OR ", escapeString(field))
 LOOP:
 	for cutoff <= max {
 		chunkIndex += 1
-		where := fmt.Sprintf("(`%s` >= %d AND `%s` < %d)", escapeString(field), cutoff, escapeString(field), cutoff+estimatedStep)
+		where := fmt.Sprintf("%s(`%s` >= %d AND `%s` < %d)", nullValueCondition, escapeString(field), cutoff, escapeString(field), cutoff+estimatedStep)
 		query = buildSelectQuery(dbName, tableName, selectedField, buildWhereCondition(conf, where), orderByClause)
 		rows, err := db.Query(query)
 		if err != nil {
 			errCh <- errors.WithMessage(err, query)
 			return
+		}
+		if len(nullValueCondition) > 0 {
+			nullValueCondition = ""
 		}
 
 		td := &tableData{


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix the problem that when picked up field is unique index NULL but dumpling skipped the NULL value.

### What is changed and how it works?
Add nullValueCondition to check for the first file like mydumper. A related integration is also added.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
- Fix the bug that dumpling omit the NULL value when `--r` is specified.
