### PR TITLE
parse tso for snapshot

### DIFF
--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"strconv"
 	"strings"
 	"time"
 
@@ -89,7 +88,7 @@ func Dump(pCtx context.Context, conf *Config) (err error) {
 	}
 
 	if doPdGC {
-		snapshotTS, err := strconv.ParseUint(conf.Snapshot, 10, 64)
+		snapshotTS, err := parseSnapshotToTSO(pool, conf.Snapshot)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
dumpling should support `datetime` type snapshot. But dumpling doesn't parse tso for `datetime` so that it fails set pd gcTS.

### What is changed and how it works?
Use `SELECT unix_timestamp("%s")` to get unix timestamp to avoid time zone problem.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
- fix bug dumpling fails to parse tso bug when tidb verison >= v4.0.0
