### PR TITLE
fix connection close and no-lock metadata(#132)

### DIFF
--- a/v4/export/connectionsPool.go
+++ b/v4/export/connectionsPool.go
@@ -6,25 +6,40 @@ import (
 )
 
 type connectionsPool struct {
-	conns chan *sql.Conn
+	conns        chan *sql.Conn
+	createdConns []*sql.Conn
 }
 
 func newConnectionsPool(ctx context.Context, n int, pool *sql.DB) (*connectionsPool, error) {
 	connectPool := &connectionsPool{
-		conns: make(chan *sql.Conn, n),
+		conns:        make(chan *sql.Conn, n),
+		createdConns: make([]*sql.Conn, 0, n),
 	}
 	for i := 0; i < n; i++ {
 		conn, err := createConnWithConsistency(ctx, pool)
 		if err != nil {
-			return nil, err
+			connectPool.Close()
+			return connectPool, err
 		}
 		connectPool.releaseConn(conn)
+		connectPool.createdConns = append(connectPool.createdConns, conn)
 	}
 	return connectPool, nil
 }
 
 func (r *connectionsPool) getConn() *sql.Conn {
 	return <-r.conns
+}
+
+func (r *connectionsPool) Close() error {
+	var err error
+	for _, conn := range r.createdConns {
+		err2 := conn.Close()
+		if err2 != nil {
+			err = err2
+		}
+	}
+	return err
 }
 
 func (r *connectionsPool) releaseConn(conn *sql.Conn) {

--- a/v4/export/consistency.go
+++ b/v4/export/consistency.go
@@ -64,7 +64,13 @@ func (c *ConsistencyFlushTableWithReadLock) Setup(ctx context.Context) error {
 }
 
 func (c *ConsistencyFlushTableWithReadLock) TearDown(ctx context.Context) error {
-	defer c.conn.Close()
+	if c.conn == nil {
+		return nil
+	}
+	defer func() {
+		c.conn.Close()
+		c.conn = nil
+	}()
 	return UnlockTables(ctx, c.conn)
 }
 
@@ -86,7 +92,13 @@ func (c *ConsistencyLockDumpingTables) Setup(ctx context.Context) error {
 }
 
 func (c *ConsistencyLockDumpingTables) TearDown(ctx context.Context) error {
-	defer c.conn.Close()
+	if c.conn == nil {
+		return nil
+	}
+	defer func() {
+		c.conn.Close()
+		c.conn = nil
+	}()
 	return UnlockTables(ctx, c.conn)
 }
 

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -147,6 +147,7 @@ func Dump(pCtx context.Context, conf *Config) (err error) {
 		return err
 	}
 
+	defer connectPool.Close()
 	// for other consistencies, we should get table list after consistency is set up and GlobalMetaData is cached
 	// for other consistencies, record snapshot after whole tables are locked. The recorded meta info is exactly the locked snapshot.
 	if conf.Consistency != "lock" {
@@ -157,6 +158,7 @@ func Dump(pCtx context.Context, conf *Config) (err error) {
 			log.Info("get global metadata failed", zap.Error(err))
 		}
 		if err = prepareTableListToDump(conf, conn); err != nil {
+			connectPool.releaseConn(conn)
 			return err
 		}
 		connectPool.releaseConn(conn)

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -147,7 +147,6 @@ func Dump(pCtx context.Context, conf *Config) (err error) {
 	// To avoid lock is not released
 	defer conCtrl.TearDown(ctx)
 
-	defer connectPool.Close()
 	// for other consistencies, we should get table list after consistency is set up and GlobalMetaData is cached
 	// for other consistencies, record snapshot after whole tables are locked. The recorded meta info is exactly the locked snapshot.
 	if conf.Consistency != "lock" {

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -123,7 +123,7 @@ func Dump(pCtx context.Context, conf *Config) (err error) {
 	if conf.Consistency == "lock" {
 		conn, err := createConnWithConsistency(ctx, pool)
 		if err != nil {
-			return err
+			return withStack(err)
 		}
 		m.recordStartTime(time.Now())
 		err = m.recordGlobalMetaData(conn, conf.ServerInfo.ServerType)
@@ -144,22 +144,32 @@ func Dump(pCtx context.Context, conf *Config) (err error) {
 	if err = conCtrl.Setup(ctx); err != nil {
 		return err
 	}
+	// To avoid lock is not released
+	defer conCtrl.TearDown(ctx)
+
+	// for other consistencies, we should get table list after consistency is set up and GlobalMetaData is cached
+	// for other consistencies, record snapshot after whole tables are locked. The recorded meta info is exactly the locked snapshot.
+	if conf.Consistency != "lock" {
+		conn, err := pool.Conn(ctx)
+		if err != nil {
+			return withStack(err)
+		}
+		m.recordStartTime(time.Now())
+		err = m.recordGlobalMetaData(conn, conf.ServerInfo.ServerType)
+		if err != nil {
+			log.Info("get global metadata failed", zap.Error(err))
+		}
+		conn.Close()
+	}
 
 	connectPool, err := newConnectionsPool(ctx, conf.Threads, pool)
 	if err != nil {
 		return err
 	}
-
 	defer connectPool.Close()
-	// for other consistencies, we should get table list after consistency is set up and GlobalMetaData is cached
-	// for other consistencies, record snapshot after whole tables are locked. The recorded meta info is exactly the locked snapshot.
+
 	if conf.Consistency != "lock" {
-		m.recordStartTime(time.Now())
 		conn := connectPool.getConn()
-		err = m.recordGlobalMetaData(conn, conf.ServerInfo.ServerType)
-		if err != nil {
-			log.Info("get global metadata failed", zap.Error(err))
-		}
 		if err = prepareTableListToDump(conf, conn); err != nil {
 			connectPool.releaseConn(conn)
 			return err

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -111,6 +111,7 @@ func Dump(pCtx context.Context, conf *Config) (err error) {
 		return withStack(err)
 	} else {
 		pool = newPool
+		defer newPool.Close()
 	}
 
 	m := newGlobalMetadata(conf.OutputDirPath)

--- a/v4/export/sql.go
+++ b/v4/export/sql.go
@@ -442,17 +442,17 @@ func resetDBWithSessionParams(db *sql.DB, dsn string, params map[string]interfac
 func createConnWithConsistency(ctx context.Context, db *sql.DB) (*sql.Conn, error) {
 	conn, err := db.Conn(ctx)
 	if err != nil {
-		return nil, err
+		return nil, withStack(err)
 	}
 	_, err = conn.ExecContext(ctx, "SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ")
 	if err != nil {
-		return nil, err
+		return nil, withStack(err)
 	}
 	_, err = conn.ExecContext(ctx, "START TRANSACTION /*!40108 WITH CONSISTENT SNAPSHOT */")
 	if err != nil {
-		return nil, err
+		return nil, withStack(err)
 	}
-	return conn, err
+	return conn, nil
 }
 
 func buildSelectField(db *sql.Conn, dbName, tableName string) (string, error) {

--- a/v4/export/writer_util.go
+++ b/v4/export/writer_util.go
@@ -151,19 +151,18 @@ func WriteInsert(pCtx context.Context, tblIR TableDataIR, w io.Writer) error {
 			row.WriteToBuffer(bf, escapeBackSlash)
 			counter += 1
 
+			fileRowIter.Next()
+			if fileRowIter.HasNext() {
+				bf.WriteString(",\n")
+			} else {
+				bf.WriteString(";\n")
+			}
 			if bf.Len() >= lengthLimit {
 				wp.input <- bf
 				bf = pool.Get().(*bytes.Buffer)
 				if bfCap := bf.Cap(); bfCap < lengthLimit {
 					bf.Grow(lengthLimit - bfCap)
 				}
-			}
-
-			fileRowIter.Next()
-			if fileRowIter.HasNext() {
-				bf.WriteString(",\n")
-			} else {
-				bf.WriteString(";\n")
 			}
 
 			select {


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
1. When dumpling `Export` is finished, db pool is not closed. Because `defer pool.Close()` only closes the previous connection pool.
2. Get metadata should be earlier than creating connection pool.(For consistency none).

### What is changed and how it works?
1. Add `defer newPool.Close()` to avoid ambiguity.
2. Put getting metadata before creating connections pool.
3. Make `consistency.TearDone` as defer to avoid lock is not released.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
