### PR TITLE
*: extend --output-filename-template to all files (except metadata)

### DIFF
--- a/cmd/dumpling/main.go
+++ b/cmd/dumpling/main.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/docker/go-units"
@@ -122,7 +121,7 @@ func main() {
 	pflag.StringVar(&keyPath, "key", "", "The path name to the client private key file for TLS connection")
 	pflag.StringVar(&csvSeparator, "csv-separator", ",", "The separator for csv files, default ','")
 	pflag.StringVar(&csvDelimiter, "csv-delimiter", "\"", "The delimiter for values in csv files, default '\"'")
-	pflag.StringVar(&outputFilenameFormat, "output-filename-template", "", "The output filename template (without file extension), default '{{.DB}}.{{.Table}}.{{.Index}}'")
+	pflag.StringVar(&outputFilenameFormat, "output-filename-template", "", "The output filename template (without file extension)")
 	pflag.BoolVar(&completeInsert, "complete-insert", false, "Use complete INSERT statements that include column names")
 
 	printVersion := pflag.BoolP("version", "V", false, "Print Dumpling version")
@@ -157,14 +156,10 @@ func main() {
 		os.Exit(2)
 	}
 
-	if outputFilenameFormat == "" {
-		if sql != "" {
-			outputFilenameFormat = "result.{{.Index}}"
-		} else {
-			outputFilenameFormat = "{{.DB}}.{{.Table}}.{{.Index}}"
-		}
+	if outputFilenameFormat == "" && sql != "" {
+		outputFilenameFormat = export.DefaultAnonymousOutputFileTemplateText
 	}
-	tmpl, err := template.New("filename").Parse(outputFilenameFormat)
+	tmpl, err := export.ParseOutputFileTemplate(outputFilenameFormat)
 	if err != nil {
 		fmt.Printf("failed to parse output filename template (--output-filename-template '%s')\n", outputFilenameFormat)
 		os.Exit(2)

--- a/docs/cn/user-guide.md
+++ b/docs/cn/user-guide.md
@@ -25,6 +25,7 @@
 | -F 或 --filesize | 将 table 数据划分出来的文件大小, 需指明单位 (如 `128B`, `64KiB`, `32MiB`, `1.5GiB`) |
 | --filetype| 导出文件类型 csv/sql (默认 sql) |
 | -o 或 --output | 设置导出文件路径 |
+| --output-filename-template | 设置导出文件名模版，详情见下 |
 | -S 或 --sql | 根据指定的 sql 导出数据，该指令不支持并发导出 |
 | --consistency | flush: dump 前用 FTWRL <br> snapshot: 通过 tso 指定 dump 位置 <br> lock: 对需要 dump 的所有表执行 lock tables read <br> none: 不加锁 dump，无法保证一致性 <br> auto: MySQL flush, TiDB snapshot|
 | --snapshot | snapshot tso, 只在 consistency=snapshot 下生效 |
@@ -44,3 +45,38 @@
 ## Dumpling 下载链接
 
 [nightly](https://download.pingcap.org/dumpling-nightly-linux-amd64.tar.gz)
+
+## 导出文件名模版
+
+`--output-filename-template` 参数指定了所有文件的命名方式（不含扩展名）。它使用 [Go 的 `text/template` 语法](https://golang.org/pkg/text/template/)。
+
+模板可使用以下字段：
+
+* `.DB` — 库名
+* `.Table` — 表名、物件名称。
+* `.Index` — 由 0 开始的序列号，代表当前导出的表中的哪一份文件
+
+库和表名中可能包含 `/` 之类的特殊字符，而这些字符不能用在文件系统中。因此，Dumpling 提供了一个 `fn` 函数来对这些特殊字符进行百分号编码。它们是：
+
+* U+0000 到 U+001F (控制字符)
+* `/`、`\`、`<`、`>`、`:`、`"`、`*`、`?` (无效的 Windows 路径字符)
+* `.` (库/表名分隔符)
+* `-`，当出现在 `-schema` 字串里
+
+例如，使用 `--output-filename-template '{{fn .Table}}.{{printf "%09d" .Index}}'` 后，Dumpling 会把表 `"db"."tbl:normal"` 导出到 `tbl%3Anormal.000000000.sql`、`tbl%3Anormal.000000001.sql` 等文件。
+
+除数据文件外，Dumpling 还支持透过子模版自定义命名表结构文件的名称。默认的配置是：
+
+| 模版名 | 默认内容 |
+|------|---------|
+| data | `{{fn .DB}}.{{fn .Table}}.{{.Index}}` |
+| schema | `{{fn .DB}}-schema-create` |
+| table | `{{fn .DB}}.{{fn .Table}}-schema` |
+| event | `{{fn .DB}}.{{fn .Table}}-schema-post` |
+| function | `{{fn .DB}}.{{fn .Table}}-schema-post` |
+| procedure | `{{fn .DB}}.{{fn .Table}}-schema-post` |
+| sequence | `{{fn .DB}}.{{fn .Table}}-schema-sequence` |
+| trigger | `{{fn .DB}}.{{fn .Table}}-schema-triggers` |
+| view | `{{fn .DB}}.{{fn .Table}}-schema-view` |
+
+例如，使用 `--output-filename-template '{{define "table"}}{{fn .Table}}.$schema{{end}}{{define "data"}}{{fn .Table}}.{{printf "%09d" .Index}}{{end}}'`后，Dumpling 会把表 `"db"."tbl:normal"` 的结构写到 `tbl%3Anormal.$schema.sql`，以及把数据写到 `tbl%3Anormal.000000000.sql`。

--- a/tests/quote/data/quote-database-schema-create.sql
+++ b/tests/quote/data/quote-database-schema-create.sql
@@ -1,1 +1,1 @@
-CREATE DATABASE `quo``te-database` /*!40100 DEFAULT CHARACTER SET latin1 */;
+CREATE DATABASE `quo``te/database` /*!40100 DEFAULT CHARACTER SET latin1 */;

--- a/tests/quote/data/quote-database.quote-table-schema.sql
+++ b/tests/quote/data/quote-database.quote-table-schema.sql
@@ -1,6 +1,6 @@
-CREATE TABLE `quo``te-table` (
-  `quo``te-col` int(11) NOT NULL,
+CREATE TABLE `quo``te/table` (
+  `quo``te/col` int(11) NOT NULL,
   `a` int(11) DEFAULT NULL,
-  `gen``id` int(11) GENERATED ALWAYS AS (`quo``te-col`) VIRTUAL,
-  PRIMARY KEY (`quo``te-col`)
+  `gen``id` int(11) GENERATED ALWAYS AS (`quo``te/col`) VIRTUAL,
+  PRIMARY KEY (`quo``te/col`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/tests/quote/data/quote-database.quote-table.0.sql
+++ b/tests/quote/data/quote-database.quote-table.0.sql
@@ -1,5 +1,5 @@
 /*!40101 SET NAMES binary*/;
-INSERT INTO `quo``te-table` (`quo``te-col`,`a`) VALUES
+INSERT INTO `quo``te/table` (`quo``te/col`,`a`) VALUES
 (0,10),
 (1,9),
 (2,8),

--- a/tests/quote/run.sh
+++ b/tests/quote/run.sh
@@ -3,17 +3,17 @@
 set -eu
 
 mkdir -p "$DUMPLING_OUTPUT_DIR"/data
-cp "$DUMPLING_BASE_NAME/data/quote-database.quote-table.0.sql" "$DUMPLING_OUTPUT_DIR/data/quo\`te-database.quo\`te-table.0.sql"
-cp "$DUMPLING_BASE_NAME/data/quote-database.quote-table-schema.sql" "$DUMPLING_OUTPUT_DIR/data/quo\`te-database.quo\`te-table-schema.sql"
-cp "$DUMPLING_BASE_NAME/data/quote-database-schema-create.sql" "$DUMPLING_OUTPUT_DIR/data/quo\`te-database-schema-create.sql"
+cp "$DUMPLING_BASE_NAME/data/quote-database.quote-table.0.sql" "$DUMPLING_OUTPUT_DIR/data/quo\`te%2Fdatabase.quo\`te%2Ftable.0.sql"
+cp "$DUMPLING_BASE_NAME/data/quote-database.quote-table-schema.sql" "$DUMPLING_OUTPUT_DIR/data/quo\`te%2Fdatabase.quo\`te%2Ftable-schema.sql"
+cp "$DUMPLING_BASE_NAME/data/quote-database-schema-create.sql" "$DUMPLING_OUTPUT_DIR/data/quo\`te%2Fdatabase-schema-create.sql"
 
-db="quo\`te-database"
-run_sql "drop database if exists \`quo\`\`te-database\`"
-run_sql_file "$DUMPLING_OUTPUT_DIR/data/quo\`te-database-schema-create.sql"
+db="quo\`te/database"
+run_sql "drop database if exists \`quo\`\`te/database\`"
+run_sql_file "$DUMPLING_OUTPUT_DIR/data/quo\`te%2Fdatabase-schema-create.sql"
 export DUMPLING_TEST_DATABASE=$db
 
-run_sql_file "$DUMPLING_OUTPUT_DIR/data/quo\`te-database.quo\`te-table-schema.sql"
-run_sql_file "$DUMPLING_OUTPUT_DIR/data/quo\`te-database.quo\`te-table.0.sql"
+run_sql_file "$DUMPLING_OUTPUT_DIR/data/quo\`te%2Fdatabase.quo\`te%2Ftable-schema.sql"
+run_sql_file "$DUMPLING_OUTPUT_DIR/data/quo\`te%2Fdatabase.quo\`te%2Ftable.0.sql"
 
 run_dumpling
 

--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -63,7 +63,6 @@ type Config struct {
 
 func DefaultConfig() *Config {
 	allFilter, _ := filter.Parse([]string{"*.*"})
-	tmpl := template.Must(template.New("filename").Parse("{{.DB}}.{{.Table}}.{{.Index}}"))
 	return &Config{
 		Databases:          nil,
 		Host:               "127.0.0.1",
@@ -93,7 +92,7 @@ func DefaultConfig() *Config {
 		TableFilter:        allFilter,
 		DumpEmptyDatabase:  true,
 		SessionParams:      make(map[string]interface{}),
-		OutputFileTemplate: tmpl,
+		OutputFileTemplate: DefaultOutputFileTemplate,
 	}
 }
 

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -183,15 +183,16 @@ func Dump(pCtx context.Context, conf *Config) (err error) {
 
 	failpoint.Inject("ConsistencyCheck", nil)
 
+	simpleWriter, err := NewSimpleWriter(conf)
+	if err != nil {
+		return err
+	}
 	var writer Writer
 	switch strings.ToLower(conf.FileType) {
 	case "sql":
-		writer, err = NewSimpleWriter(conf)
+		writer = SQLWriter{SimpleWriter: simpleWriter}
 	case "csv":
-		writer, err = NewCsvWriter(conf)
-	}
-	if err != nil {
-		return err
+		writer = CSVWriter{SimpleWriter: simpleWriter}
 	}
 
 	if conf.Sql == "" {

--- a/v4/export/prepare.go
+++ b/v4/export/prepare.go
@@ -2,6 +2,8 @@ package export
 
 import (
 	"database/sql"
+	"fmt"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -10,6 +12,63 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb-tools/pkg/utils"
 )
+
+const (
+	outputFileTemplateSchema = "schema"
+	outputFileTemplateTable  = "table"
+	outputFileTemplateData   = "data"
+
+	defaultOutputFileTemplateBase = `
+		{{- define "objectName" -}}
+			{{fn .DB}}.{{fn .Table}}
+		{{- end -}}
+		{{- define "schema" -}}
+			{{fn .DB}}-schema-create
+		{{- end -}}
+		{{- define "event" -}}
+			{{template "objectName" .}}-schema-post
+		{{- end -}}
+		{{- define "function" -}}
+			{{template "objectName" .}}-schema-post
+		{{- end -}}
+		{{- define "procedure" -}}
+			{{template "objectName" .}}-schema-post
+		{{- end -}}
+		{{- define "sequence" -}}
+			{{template "objectName" .}}-schema-sequence
+		{{- end -}}
+		{{- define "trigger" -}}
+			{{template "objectName" .}}-schema-triggers
+		{{- end -}}
+		{{- define "view" -}}
+			{{template "objectName" .}}-schema-view
+		{{- end -}}
+		{{- define "table" -}}
+			{{template "objectName" .}}-schema
+		{{- end -}}
+		{{- define "data" -}}
+			{{template "objectName" .}}.{{.Index}}
+		{{- end -}}
+	`
+
+	DefaultAnonymousOutputFileTemplateText = "result.{{.Index}}"
+)
+
+var filenameEscapeRegexp = regexp.MustCompile(`[\x00-\x1f%"*./:<>?\\|]|-(?i:schema)`)
+var DefaultOutputFileTemplate = template.Must(template.New("data").
+	Option("missingkey=error").
+	Funcs(template.FuncMap{
+		"fn": func(input string) string {
+			return filenameEscapeRegexp.ReplaceAllStringFunc(input, func(match string) string {
+				return fmt.Sprintf("%%%02X%s", match[0], match[1:])
+			})
+		},
+	}).
+	Parse(defaultOutputFileTemplateBase))
+
+func ParseOutputFileTemplate(text string) (*template.Template, error) {
+	return template.Must(DefaultOutputFileTemplate.Clone()).Parse(text)
+}
 
 func adjustConfig(conf *Config) error {
 	// Init logger
@@ -46,11 +105,7 @@ func adjustConfig(conf *Config) error {
 		conf.SessionParams = make(map[string]interface{})
 	}
 	if conf.OutputFileTemplate == nil {
-		var err error
-		conf.OutputFileTemplate, err = template.New("filename").Parse("{{.DB}}.{{.Table}}.{{.Index}}")
-		if err != nil {
-			return err
-		}
+		conf.OutputFileTemplate = DefaultOutputFileTemplate
 	}
 
 	return nil

--- a/v4/export/writer.go
+++ b/v4/export/writer.go
@@ -3,7 +3,6 @@ package export
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"os"
 	"path"
 	"text/template"
@@ -23,24 +22,32 @@ type SimpleWriter struct {
 	cfg *Config
 }
 
-func NewSimpleWriter(config *Config) (Writer, error) {
-	sw := &SimpleWriter{cfg: config}
+func NewSimpleWriter(config *Config) (SimpleWriter, error) {
+	sw := SimpleWriter{cfg: config}
 	return sw, os.MkdirAll(config.OutputDirPath, 0755)
 }
 
-func (f *SimpleWriter) WriteDatabaseMeta(ctx context.Context, db, createSQL string) error {
-	fileName := fmt.Sprintf("%s-schema-create.sql", db)
-	filePath := path.Join(f.cfg.OutputDirPath, fileName)
+func (f SimpleWriter) WriteDatabaseMeta(ctx context.Context, db, createSQL string) error {
+	fileName, err := (&outputFileNamer{DB: db}).render(f.cfg.OutputFileTemplate, outputFileTemplateSchema)
+	if err != nil {
+		return err
+	}
+	filePath := path.Join(f.cfg.OutputDirPath, fileName+".sql")
 	return writeMetaToFile(db, createSQL, filePath)
 }
 
-func (f *SimpleWriter) WriteTableMeta(ctx context.Context, db, table, createSQL string) error {
-	fileName := fmt.Sprintf("%s.%s-schema.sql", db, table)
-	filePath := path.Join(f.cfg.OutputDirPath, fileName)
+func (f SimpleWriter) WriteTableMeta(ctx context.Context, db, table, createSQL string) error {
+	fileName, err := (&outputFileNamer{DB: db, Table: table}).render(f.cfg.OutputFileTemplate, outputFileTemplateTable)
+	if err != nil {
+		return err
+	}
+	filePath := path.Join(f.cfg.OutputDirPath, fileName+".sql")
 	return writeMetaToFile(db, createSQL, filePath)
 }
 
-func (f *SimpleWriter) WriteTableData(ctx context.Context, ir TableDataIR) error {
+type SQLWriter struct{ SimpleWriter }
+
+func (f SQLWriter) WriteTableData(ctx context.Context, ir TableDataIR) error {
 	log.Debug("start dumping table...", zap.String("table", ir.TableName()))
 
 	// just let `database.table.sql` be `database.table.0.sql`
@@ -100,26 +107,7 @@ func writeMetaToFile(target, metaSQL, path string) error {
 	}, fileWriter)
 }
 
-type CsvWriter struct {
-	cfg *Config
-}
-
-func NewCsvWriter(config *Config) (Writer, error) {
-	sw := &CsvWriter{cfg: config}
-	return sw, os.MkdirAll(config.OutputDirPath, 0755)
-}
-
-func (f *CsvWriter) WriteDatabaseMeta(ctx context.Context, db, createSQL string) error {
-	fileName := fmt.Sprintf("%s-schema-create.sql", db)
-	filePath := path.Join(f.cfg.OutputDirPath, fileName)
-	return writeMetaToFile(db, createSQL, filePath)
-}
-
-func (f *CsvWriter) WriteTableMeta(ctx context.Context, db, table, createSQL string) error {
-	fileName := fmt.Sprintf("%s.%s-schema.sql", db, table)
-	filePath := path.Join(f.cfg.OutputDirPath, fileName)
-	return writeMetaToFile(db, createSQL, filePath)
-}
+type CSVWriter struct{ SimpleWriter }
 
 type outputFileNamer struct {
 	Index int
@@ -141,17 +129,21 @@ func newOutputFileNamer(ir TableDataIR) *outputFileNamer {
 	}
 }
 
-func (namer *outputFileNamer) NextName(tmpl *template.Template) (string, error) {
-	defer func() { namer.Index++ }()
-	bf := bytes.NewBufferString("")
-	err := tmpl.Execute(bf, namer)
-	if err != nil {
+func (namer *outputFileNamer) render(tmpl *template.Template, subName string) (string, error) {
+	var bf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&bf, subName, namer); err != nil {
 		return "", err
 	}
 	return bf.String(), nil
 }
 
-func (f *CsvWriter) WriteTableData(ctx context.Context, ir TableDataIR) error {
+func (namer *outputFileNamer) NextName(tmpl *template.Template) (string, error) {
+	res, err := namer.render(tmpl, outputFileTemplateData)
+	namer.Index++
+	return res, err
+}
+
+func (f CSVWriter) WriteTableData(ctx context.Context, ir TableDataIR) error {
 	log.Debug("start dumping table in csv format...", zap.String("table", ir.TableName()))
 
 	namer := newOutputFileNamer(ir)


### PR DESCRIPTION
introduced function to escape the database and table names

<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

* Close #131. 

### What is changed and how it works?

* We introduced a template function `fn` to percent-escape the special characters in the database and table names.
* Because #131 affects schema files too, we here also cover the schema file names under `--output-filename-template`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

 - Increased code complexity

Related changes

 - Need to update the documentation
 
### Release note

- Table names with special characters like `/` are percent-escaped as `%2F` by default. 
- `--output-filename-template` can be used to define the name templates for schema files.