### PR TITLE
export: record location after connection pool established

### DIFF
--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -60,6 +60,8 @@ type Config struct {
 	DumpEmptyDatabase  bool
 	OutputFileTemplate *template.Template `json:"-"`
 	SessionParams      map[string]interface{}
+
+	PosAfterConnect bool
 }
 
 func DefaultConfig() *Config {
@@ -94,6 +96,7 @@ func DefaultConfig() *Config {
 		DumpEmptyDatabase:  true,
 		SessionParams:      make(map[string]interface{}),
 		OutputFileTemplate: DefaultOutputFileTemplate,
+		PosAfterConnect:    false,
 	}
 }
 

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -126,7 +126,7 @@ func Dump(pCtx context.Context, conf *Config) (err error) {
 			return withStack(err)
 		}
 		m.recordStartTime(time.Now())
-		err = m.recordGlobalMetaData(conn, conf.ServerInfo.ServerType)
+		err = m.recordGlobalMetaData(conn, conf.ServerInfo.ServerType, false)
 		if err != nil {
 			log.Info("get global metadata failed", zap.Error(err))
 		}
@@ -155,7 +155,7 @@ func Dump(pCtx context.Context, conf *Config) (err error) {
 			return withStack(err)
 		}
 		m.recordStartTime(time.Now())
-		err = m.recordGlobalMetaData(conn, conf.ServerInfo.ServerType)
+		err = m.recordGlobalMetaData(conn, conf.ServerInfo.ServerType, false)
 		if err != nil {
 			log.Info("get global metadata failed", zap.Error(err))
 		}
@@ -170,6 +170,11 @@ func Dump(pCtx context.Context, conf *Config) (err error) {
 
 	if conf.Consistency != "lock" {
 		conn := connectPool.getConn()
+		// record again, to provide a location to exit safe mode for DM
+		err = m.recordGlobalMetaData(conn, conf.ServerInfo.ServerType, true)
+		if err != nil {
+			log.Info("get global metadata (after connection pool established) failed", zap.Error(err))
+		}
 		if err = prepareTableListToDump(conf, conn); err != nil {
 			connectPool.releaseConn(conn)
 			return err


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
support DM's scenario: when migrate from a DB that can't FTWRL, dumpling uses inconsistent dump. Record the location after connection pool established to indicate DM leave safe mode

### What is changed and how it works?
metadata now

```
Started dump at: 2020-08-26 17:54:52
SHOW MASTER STATUS:
	Log: mysql-bin.000002
	Pos: 194
	GTID:09bec856-ba95-11ea-850a-58f2b4af5188:1-103
SHOW MASTER STATUS: /* AFTER CONNECTION POOL ESTABLISHED */
	Log: mysql-bin.000002
	Pos: 199
	GTID:09bec856-ba95-11ea-850a-58f2b4af5188:1-103

Finished dump at: 2020-08-26 17:54:52
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

Related changes
 
### Release note

- No release note
