### PR TITLE
improve dumpling error info

### DIFF
--- a/v4/export/prepare.go
+++ b/v4/export/prepare.go
@@ -107,6 +107,9 @@ func adjustConfig(conf *Config) error {
 	if conf.OutputFileTemplate == nil {
 		conf.OutputFileTemplate = DefaultOutputFileTemplate
 	}
+	if conf.Sql != "" && conf.Where != "" {
+		return errors.New("can't specify both --where and --sql at the same time")
+	}
 
 	return nil
 }

--- a/v4/export/prepare.go
+++ b/v4/export/prepare.go
@@ -108,7 +108,7 @@ func adjustConfig(conf *Config) error {
 		conf.OutputFileTemplate = DefaultOutputFileTemplate
 	}
 	if conf.Sql != "" && conf.Where != "" {
-		return errors.New("can't specify both --where and --sql at the same time")
+		return errors.New("can't specify both --sql and --where at the same time. Please try to combine them into --sql")
 	}
 
 	return nil

--- a/v4/export/prepare_test.go
+++ b/v4/export/prepare_test.go
@@ -114,7 +114,7 @@ func (s *testPrepareSuite) TestAdjustConfig(c *C) {
 	conf := DefaultConfig()
 	conf.Where = "id < 5"
 	conf.Sql = "select * from t where id > 3"
-	c.Assert(adjustConfig(conf), ErrorMatches, "can't specify both --where and --sql at the same time")
+	c.Assert(adjustConfig(conf), ErrorMatches, "can't specify both --sql and --where at the same time. Please try to combine them into --sql")
 	conf.Where = ""
 	c.Assert(adjustConfig(conf), IsNil)
 	conf.Sql = ""

--- a/v4/export/prepare_test.go
+++ b/v4/export/prepare_test.go
@@ -109,3 +109,17 @@ func (s *testPrepareSuite) TestListAllTables(c *C) {
 
 	c.Assert(mock.ExpectationsWereMet(), IsNil)
 }
+
+func (s *testPrepareSuite) TestAdjustConfig(c *C) {
+	conf := DefaultConfig()
+	conf.Where = "id < 5"
+	conf.Sql = "select * from t where id > 3"
+	c.Assert(adjustConfig(conf), ErrorMatches, "can't specify both --where and --sql at the same time")
+	conf.Where = ""
+	c.Assert(adjustConfig(conf), IsNil)
+	conf.Sql = ""
+	conf.Rows = 5000
+	conf.FileSize = uint64(5000)
+	c.Assert(adjustConfig(conf), IsNil)
+	c.Assert(conf.FileSize, Equals, uint64(UnspecifiedSize))
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Dumpling's error hint is not clear enough.

### What is changed and how it works?
1. add SQL to database error message
2. Users can't specify `where` and `sql` option at the same time. dumpling will return an error in `adjust` now. close #154.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
