### PR TITLE
Allow clear text password

### DIFF
--- a/cmd/dumpling/main.go
+++ b/cmd/dumpling/main.go
@@ -35,38 +35,39 @@ import (
 )
 
 var (
-	databases     []string
-	tablesList    []string
-	host          string
-	user          string
-	port          int
-	password      string
-	threads       int
-	outputDir     string
-	fileSizeStr   string
-	statementSize uint64
-	logLevel      string
-	logFile       string
-	logFormat     string
-	consistency   string
-	snapshot      string
-	noViews       bool
-	statusAddr    string
-	rows          uint64
-	where         string
-	fileType      string
-	noHeader      bool
-	noSchemas     bool
-	noData        bool
-	csvNullValue  string
-	sql           string
-	filters       []string
-	caseSensitive bool
-	caPath        string
-	certPath      string
-	keyPath       string
-	csvSeparator  string
-	csvDelimiter  string
+	databases               []string
+	tablesList              []string
+	host                    string
+	user                    string
+	port                    int
+	password                string
+	allowCleartextPasswords bool
+	threads                 int
+	outputDir               string
+	fileSizeStr             string
+	statementSize           uint64
+	logLevel                string
+	logFile                 string
+	logFormat               string
+	consistency             string
+	snapshot                string
+	noViews                 bool
+	statusAddr              string
+	rows                    uint64
+	where                   string
+	fileType                string
+	noHeader                bool
+	noSchemas               bool
+	noData                  bool
+	csvNullValue            string
+	sql                     string
+	filters                 []string
+	caseSensitive           bool
+	caPath                  string
+	certPath                string
+	keyPath                 string
+	csvSeparator            string
+	csvDelimiter            string
 
 	completeInsert       bool
 	dumpEmptyDatabase    bool
@@ -94,6 +95,7 @@ func main() {
 	pflag.StringVarP(&user, "user", "u", "root", "Username with privileges to run the dump")
 	pflag.IntVarP(&port, "port", "P", 4000, "TCP/IP port to connect to")
 	pflag.StringVarP(&password, "password", "p", "", "User password")
+	pflag.BoolVar(&allowCleartextPasswords, "allow-cleartext-passwords", false, "Allow passwords to be sent in cleartext (warning: don't use without TLS)")
 	pflag.IntVarP(&threads, "threads", "t", 4, "Number of goroutines to use, default 4")
 	pflag.StringVarP(&fileSizeStr, "filesize", "F", "", "The approximate size of output file")
 	pflag.Uint64VarP(&statementSize, "statement-size", "s", export.UnspecifiedSize, "Attempted size of INSERT statement in bytes")
@@ -180,6 +182,7 @@ func main() {
 	conf.User = user
 	conf.Port = port
 	conf.Password = password
+	conf.AllowCleartextPasswords = allowCleartextPasswords
 	conf.Threads = threads
 	conf.FileSize = fileSize
 	conf.StatementSize = statementSize

--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -20,12 +20,13 @@ import (
 type Config struct {
 	storage.BackendOptions
 
-	Databases []string
-	Host      string
-	User      string
-	Port      int
-	Password  string `json:"-"`
-	Security  struct {
+	Databases               []string
+	Host                    string
+	User                    string
+	Port                    int
+	Password                string `json:"-"`
+	AllowCleartextPasswords bool
+	Security                struct {
 		CAPath   string
 		CertPath string
 		KeyPath  string
@@ -120,6 +121,9 @@ func (conf *Config) GetDSN(db string) string {
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8mb4", conf.User, conf.Password, conf.Host, conf.Port, db)
 	if len(conf.Security.CAPath) > 0 {
 		dsn += "&tls=dumpling-tls-target"
+	}
+	if conf.AllowCleartextPasswords {
+		dsn += "&allowCleartextPasswords=1"
 	}
 	return dsn
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

`--allow-cleartext-password` is required to be able to use Aurora token authentication. It's always combined with TLS so is not actually sent in clear on the wire.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

### Release note

- support Aurora token authentication with --allow-cleartext-password
