### PR TITLE
set default statement size for dumpling

### DIFF
--- a/cmd/dumpling/main.go
+++ b/cmd/dumpling/main.go
@@ -98,7 +98,7 @@ func main() {
 	pflag.BoolVar(&allowCleartextPasswords, "allow-cleartext-passwords", false, "Allow passwords to be sent in cleartext (warning: don't use without TLS)")
 	pflag.IntVarP(&threads, "threads", "t", 4, "Number of goroutines to use, default 4")
 	pflag.StringVarP(&fileSizeStr, "filesize", "F", "", "The approximate size of output file")
-	pflag.Uint64VarP(&statementSize, "statement-size", "s", export.UnspecifiedSize, "Attempted size of INSERT statement in bytes")
+	pflag.Uint64VarP(&statementSize, "statement-size", "s", export.DefaultStatementSize, "Attempted size of INSERT statement in bytes")
 	pflag.StringVarP(&outputDir, "output", "o", defaultOutputDir, "Output directory")
 	pflag.StringVar(&logLevel, "loglevel", "info", "Log level: {debug|info|warn|error|dpanic|panic|fatal}")
 	pflag.StringVarP(&logFile, "logfile", "L", "", "Log file `path`, leave empty to write to console")

--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -84,7 +84,7 @@ func DefaultConfig() *Config {
 		Logger:             nil,
 		StatusAddr:         ":8281",
 		FileSize:           UnspecifiedSize,
-		StatementSize:      UnspecifiedSize,
+		StatementSize:      DefaultStatementSize,
 		OutputDirPath:      ".",
 		ServerInfo:         ServerInfoUnknown,
 		SortByPk:           true,

--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -139,6 +139,7 @@ func (config *Config) createExternalStorage(ctx context.Context) (storage.Extern
 const (
 	UnspecifiedSize            = 0
 	DefaultTiDBMemQuotaQuery   = 32 * (1 << 30)
+	DefaultStatementSize       = 1000000
 	defaultDumpThreads         = 128
 	defaultDumpGCSafePointTTL  = 5 * 60
 	dumplingServiceSafePointID = "dumpling"


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
If the user doesn't set `statement-size`, the dumped statement in the SQL file might be really huge.

### What is changed and how it works?
set default `statement-size` to `1000000`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
