### PR TITLE
order selected field by ORDINAL_POSITION

### DIFF
--- a/v4/export/sql.go
+++ b/v4/export/sql.go
@@ -519,7 +519,7 @@ func createConnWithConsistency(ctx context.Context, db *sql.DB) (*sql.Conn, erro
 }
 
 func buildSelectField(db *sql.Conn, dbName, tableName string, completeInsert bool) (string, error) {
-	query := `SELECT COLUMN_NAME,EXTRA FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA=? AND TABLE_NAME=?;`
+	query := `SELECT COLUMN_NAME,EXTRA FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA=? AND TABLE_NAME=? ORDER BY ORDINAL_POSITION;`
 	rows, err := db.QueryContext(context.Background(), query, dbName, tableName)
 	if err != nil {
 		return "", withStack(errors.WithMessage(err, query))


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
For MySQL 8.0+ selected fields may not be returned in the original order. (In MySQL 5.7+ and TiDB they do)
```sql
mysql> SELECT COLUMN_NAME,EXTRA,ORDINAL_POSITION FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA='test' AND TABLE_NAME='t_1';
+-------------+----------------+------------------+
| COLUMN_NAME | EXTRA          | ORDINAL_POSITION |
+-------------+----------------+------------------+
| b           |                |                2 |
| c           |                |                3 |
| d           |                |                4 |
| id          | auto_increment |                1 |
+-------------+----------------+------------------+
4 rows in set (0.00 sec)

mysql> select version();
+-----------+
| version() |
+-----------+
| 8.0.19    |
+-----------+
1 row in set (0.01 sec)
```

### What is changed and how it works?
Add `ORDER BY ORDINAL_POSITION` in `buildSelectField`. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
  Dumped MySQL 8.0.19 SQL files are in the original order.

Related changes

 - Need to cherry-pick to the release branch
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
- No release note
