### PR TITLE
support session parameters

### DIFF
--- a/cmd/dumpling/main.go
+++ b/cmd/dumpling/main.go
@@ -68,6 +68,7 @@ var (
 	keyPath                 string
 	csvSeparator            string
 	csvDelimiter            string
+	sessionParams           map[string]string
 
 	completeInsert       bool
 	dumpEmptyDatabase    bool
@@ -127,6 +128,7 @@ func main() {
 	pflag.StringVar(&csvDelimiter, "csv-delimiter", "\"", "The delimiter for values in csv files, default '\"'")
 	pflag.StringVar(&outputFilenameFormat, "output-filename-template", "", "The output filename template (without file extension)")
 	pflag.BoolVar(&completeInsert, "complete-insert", false, "Use complete INSERT statements that include column names")
+	pflag.StringToStringVar(&sessionParams, "params", nil, `Extra session params used in dumping process, accept format: --params "character_set_client=latin1,character_set_connection=latin1"`)
 
 	storage.DefineFlags(pflag.CommandLine)
 
@@ -177,6 +179,9 @@ func main() {
 	}
 
 	conf := export.DefaultConfig()
+	for k, v := range sessionParams {
+		conf.SessionParams[k] = v
+	}
 	conf.Databases = databases
 	conf.Host = host
 	conf.User = user

--- a/cmd/dumpling/main.go
+++ b/cmd/dumpling/main.go
@@ -128,7 +128,7 @@ func main() {
 	pflag.StringVar(&csvDelimiter, "csv-delimiter", "\"", "The delimiter for values in csv files, default '\"'")
 	pflag.StringVar(&outputFilenameFormat, "output-filename-template", "", "The output filename template (without file extension)")
 	pflag.BoolVar(&completeInsert, "complete-insert", false, "Use complete INSERT statements that include column names")
-	pflag.StringToStringVar(&sessionParams, "params", nil, `Extra session params used in dumping process, accept format: --params "character_set_client=latin1,character_set_connection=latin1"`)
+	pflag.StringToStringVar(&sessionParams, "params", nil, `Extra session variables used while dumping, accepted format: --params "character_set_client=latin1,character_set_connection=latin1"`)
 
 	storage.DefineFlags(pflag.CommandLine)
 

--- a/cmd/dumpling/main.go
+++ b/cmd/dumpling/main.go
@@ -213,7 +213,7 @@ func main() {
 	conf.Security.CAPath = caPath
 	conf.Security.CertPath = certPath
 	conf.Security.KeyPath = keyPath
-	conf.SessionParams["tidb_mem_quota_query"] = tidbMemQuotaQuery
+	conf.SessionParams[export.TiDBMemQuotaQueryName] = tidbMemQuotaQuery
 	conf.CsvSeparator = csvSeparator
 	conf.CsvDelimiter = csvDelimiter
 	conf.OutputFileTemplate = tmpl

--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -137,9 +137,11 @@ func (config *Config) createExternalStorage(ctx context.Context) (storage.Extern
 }
 
 const (
-	UnspecifiedSize            = 0
-	DefaultTiDBMemQuotaQuery   = 32 * (1 << 30)
-	DefaultStatementSize       = 1000000
+	UnspecifiedSize          = 0
+	DefaultTiDBMemQuotaQuery = 32 * (1 << 30)
+	DefaultStatementSize     = 1000000
+	TiDBMemQuotaQueryName    = "tidb_mem_quota_query"
+
 	defaultDumpThreads         = 128
 	defaultDumpGCSafePointTTL  = 5 * 60
 	dumplingServiceSafePointID = "dumpling"

--- a/v4/export/sql.go
+++ b/v4/export/sql.go
@@ -481,13 +481,7 @@ func resetDBWithSessionParams(db *sql.DB, dsn string, params map[string]interfac
 	}
 
 	for k, v := range support {
-		var s string
-		if str, ok := v.(string); ok {
-			s = wrapStringWith(str, "'")
-		} else {
-			s = fmt.Sprintf("%v", v)
-		}
-		dsn += fmt.Sprintf("&%s=%s", k, url.QueryEscape(s))
+		dsn += fmt.Sprintf("&%s=%s", k, url.QueryEscape(fmt.Sprintf("%v", v)))
 	}
 
 	newDB, err := sql.Open("mysql", dsn)

--- a/v4/export/sql.go
+++ b/v4/export/sql.go
@@ -482,6 +482,8 @@ func resetDBWithSessionParams(db *sql.DB, dsn string, params map[string]interfac
 
 	for k, v := range support {
 		var s string
+		// Wrap string with quote to handle string with space. For example, '2020-10-20 13:41:40'
+		// For --params argument, quote doesn't matter because it doesn't affect the actual value
 		if str, ok := v.(string); ok {
 			s = wrapStringWith(str, "'")
 		} else {

--- a/v4/export/sql.go
+++ b/v4/export/sql.go
@@ -481,7 +481,13 @@ func resetDBWithSessionParams(db *sql.DB, dsn string, params map[string]interfac
 	}
 
 	for k, v := range support {
-		dsn += fmt.Sprintf("&%s=%s", k, url.QueryEscape(fmt.Sprintf("%v", v)))
+		var s string
+		if str, ok := v.(string); ok {
+			s = wrapStringWith(str, "'")
+		} else {
+			s = fmt.Sprintf("%v", v)
+		}
+		dsn += fmt.Sprintf("&%s=%s", k, url.QueryEscape(s))
 	}
 
 	newDB, err := sql.Open("mysql", dsn)


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Dumpling doesn't support customized session variables now.

### What is changed and how it works?
Add `params` argument to support session params in dumping progress. For example, `--params "character_set_client=latin1,character_set_connection=latin1"`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
  Manually set `--params` and it looks good.

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->

- support --params argument