### PR TITLE
fix metadata for earlier mysql

### DIFF
--- a/v4/export/consistency.go
+++ b/v4/export/consistency.go
@@ -102,7 +102,6 @@ func (c *ConsistencyLockDumpingTables) TearDown(ctx context.Context) error {
 	return UnlockTables(ctx, c.conn)
 }
 
-const showMasterStatusFieldNum = 5
 const snapshotFieldIndex = 1
 
 func resolveAutoConsistency(conf *Config) {

--- a/v4/export/sql.go
+++ b/v4/export/sql.go
@@ -375,13 +375,19 @@ func UseDatabase(db *sql.DB, databaseName string) error {
 	return withStack(err)
 }
 
-func ShowMasterStatus(db *sql.Conn, fieldNum int) ([]string, error) {
-	oneRow := make([]string, fieldNum)
-	addr := make([]interface{}, fieldNum)
-	for i := range oneRow {
-		addr[i] = &oneRow[i]
-	}
+func ShowMasterStatus(db *sql.Conn) ([]string, error) {
+	var oneRow []string
 	handleOneRow := func(rows *sql.Rows) error {
+		cols, err := rows.Columns()
+		if err != nil {
+			return err
+		}
+		fieldNum := len(cols)
+		oneRow = make([]string, fieldNum)
+		addr := make([]interface{}, fieldNum)
+		for i := range oneRow {
+			addr[i] = &oneRow[i]
+		}
 		return rows.Scan(addr...)
 	}
 	const showMasterStatusQuery = "SHOW MASTER STATUS"
@@ -453,7 +459,7 @@ func CheckTiDBWithTiKV(db *sql.DB) (bool, error) {
 }
 
 func getSnapshot(db *sql.Conn) (string, error) {
-	str, err := ShowMasterStatus(db, showMasterStatusFieldNum)
+	str, err := ShowMasterStatus(db)
 	if err != nil {
 		return "", err
 	}

--- a/v4/export/writer_util.go
+++ b/v4/export/writer_util.go
@@ -8,9 +8,8 @@ import (
 	"strings"
 	"sync"
 
-	"go.uber.org/zap"
-
 	"github.com/pingcap/br/pkg/storage"
+	"go.uber.org/zap"
 
 	"github.com/pingcap/dumpling/v4/log"
 )

--- a/v4/export/writer_util.go
+++ b/v4/export/writer_util.go
@@ -193,19 +193,17 @@ func WriteInsert(pCtx context.Context, tblIR TableDataIR, w storage.Writer, file
 				bf.WriteString(";\n")
 			}
 			if bf.Len() >= lengthLimit {
-				wp.input <- bf
-				bf = pool.Get().(*bytes.Buffer)
-				if bfCap := bf.Cap(); bfCap < lengthLimit {
-					bf.Grow(lengthLimit - bfCap)
+				select {
+				case <-pCtx.Done():
+					return pCtx.Err()
+				case err := <-wp.errCh:
+					return err
+				case wp.input <- bf:
+					bf = pool.Get().(*bytes.Buffer)
+					if bfCap := bf.Cap(); bfCap < lengthLimit {
+						bf.Grow(lengthLimit - bfCap)
+					}
 				}
-			}
-
-			select {
-			case <-pCtx.Done():
-				return pCtx.Err()
-			case err := <-wp.errCh:
-				return err
-			default:
 			}
 
 			if shouldSwitch {
@@ -288,21 +286,20 @@ func WriteInsertInCsv(pCtx context.Context, tblIR TableDataIR, w storage.Writer,
 
 		bf.WriteByte('\n')
 		if bf.Len() >= lengthLimit {
-			wp.input <- bf
-			bf = pool.Get().(*bytes.Buffer)
-			if bfCap := bf.Cap(); bfCap < lengthLimit {
-				bf.Grow(lengthLimit - bfCap)
+			select {
+			case <-pCtx.Done():
+				return pCtx.Err()
+			case err := <-wp.errCh:
+				return err
+			case wp.input <- bf:
+				bf = pool.Get().(*bytes.Buffer)
+				if bfCap := bf.Cap(); bfCap < lengthLimit {
+					bf.Grow(lengthLimit - bfCap)
+				}
 			}
 		}
 
 		fileRowIter.Next()
-		select {
-		case <-pCtx.Done():
-			return pCtx.Err()
-		case err := <-wp.errCh:
-			return err
-		default:
-		}
 		if wp.ShouldSwitchFile() {
 			break
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When dumpling dumps data from earlier MySQL who doesn't have GTID (for example, MySQL 5.5.60), dumpling will fail to generate metadata.
```sql
mysql> select version();
+------------+
| version()  |
+------------+
| 5.5.60-log |
+------------+
1 row in set (0.00 sec)

mysql> show master status;
+------------------+----------+--------------+------------------+
| File             | Position | Binlog_Do_DB | Binlog_Ignore_DB |
+------------------+----------+--------------+------------------+
| mysql-bin.000001 |     4879 |              |                  |
+------------------+----------+--------------+------------------+
1 row in set (0.00 sec)
```
```log
[2020/10/22 14:33:07.112 +08:00] [INFO] [config.go:180] ["detect server type"] [type=MySQL]
[2020/10/22 14:33:07.112 +08:00] [INFO] [config.go:198] ["detect server version"] [version=5.5.60-log]
[2020/10/22 14:33:07.120 +08:00] [INFO] [dump.go:164] ["get global metadata failed"] [error="SHOW MASTER STATUS: SHOW MASTER STATUS: sql: expected 4 destination arguments in Scan, not 5"] [errorVerbose="err = SHOW MASTER STATUS: sql: expected 4 destination arguments in Scan, not 5\ngoroutine 1 [running]:\nruntime/debug.Stack(0x209a6c0, 0xc00000e5a0, 0x209c300)\n\t/usr/local/go/src/runtime/debug/stack.go:24 +0x9d\ngithub.com/pingcap/dumpling/v4/export.withStack(0x209a6c0, 0xc00000e5a0, 0x0, 0x0)\n\t/Users/chauncy/code/goPath/src/github.com/pingcap/dumpling/v4/export/error.go:59 +0x8d\ngithub.com/pingcap/dumpling/v4/export.simpleQueryWithArgs(0xc000429500, 0xc000282ff8, 0x1e1f09b, 0x12, 0x0, 0x0, 0x0, 0x0, 0x0)\n\t/Users/chauncy/code/goPath/src/github.com/pingcap/dumpling/v4/export/sql.go:580 +0x2ae\ngithub.com/pingcap/dumpling/v4/export.simpleQuery(...)\n\t/Users/chauncy/code/goPath/src/github.com/pingcap/dumpling/v4/export/sql.go:567\ngithub.com/pingcap/dumpling/v4/export.ShowMasterStatus(0xc000429500, 0x5, 0x1, 0x1, 0x0, 0x0, 0xc00014f580)\n\t/Users/chauncy/code/goPath/src/github.com/pingcap/dumpling/v4/export/sql.go:388 +0x14a\ngithub.com/pingcap/dumpling/v4/export.(*globalMetadata).recordGlobalMetaData(0xc000090e00, 0xc000429500, 0x1aa0001, 0x28c5fa0, 0x0)\n\t/Users/chauncy/code/goPath/src/github.com/pingcap/dumpling/v4/export/metadata.go:77 +0xba\ngithub.com/pingcap/dumpling/v4/export.Dump(0x20bd620, 0xc0000bc000, 0xc00045a000, 0x0, 0x0)\n\t/Users/chauncy/code/goPath/src/github.com/pingcap/dumpling/v4/export/dump.go:162 +0x760\nmain.main()\n\t/Users/chauncy/code/goPath/src/github.com/pingcap/dumpling/cmd/dumpling/main.go:228 +0x1755\n\nSHOW MASTER STATUS"]
[2020/10/22 14:33:07.345 +08:00] [INFO] [main.go:234] ["dump data successfully, dumpling will exit now"]
```

### What is changed and how it works?
1. Don't set fixed columns when `show master status`.
2. Unify the metadata format with mydumper's.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
  Test dumping MySQL 5.5.60, the metadata is generated correctly.
```log
[2020/10/22 15:01:00.356 +08:00] [INFO] [config.go:180] ["detect server type"] [type=MySQL]
[2020/10/22 15:01:00.356 +08:00] [INFO] [config.go:198] ["detect server version"] [version=5.5.60-log]
[2020/10/22 15:01:00.588 +08:00] [INFO] [main.go:234] ["dump data successfully, dumpling will exit now"]
```
```
Started dump at: 2020-10-22 15:01:00
SHOW MASTER STATUS:
	Log: mysql-bin.000001
	Pos: 4879
	GTID:

Finished dump at: 2020-10-22 15:01:00
```

Related changes

 - Need to cherry-pick to the release branch
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
- Fix the problem that metadata is not generated correctly for earlier MySQL