### PR TITLE
Compatible with tidb who doesn't have prefix 'v' on version info

### DIFF
--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -510,7 +510,7 @@ var ServerInfoUnknown = ServerInfo{
 }
 
 var versionRegex = regexp.MustCompile(`^\d+\.\d+\.\d+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?`)
-var tidbVersionRegex = regexp.MustCompile(`v\d+\.\d+\.\d+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?`)
+var tidbVersionRegex = regexp.MustCompile(`-[v]?\d+\.\d+\.\d+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?`)
 
 func ParseServerInfo(src string) ServerInfo {
 	log.Debug("parse server info", zap.String("server info string", src))
@@ -532,6 +532,7 @@ func ParseServerInfo(src string) ServerInfo {
 	var versionStr string
 	if serverInfo.ServerType == ServerTypeTiDB {
 		versionStr = tidbVersionRegex.FindString(src)[1:]
+		versionStr = strings.TrimPrefix(versionStr, "v")
 	} else {
 		versionStr = versionRegex.FindString(src)
 	}

--- a/v4/export/sql_test.go
+++ b/v4/export/sql_test.go
@@ -24,7 +24,8 @@ func (s *testDumpSuite) TestDetectServerInfo(c *C) {
 		{2, "10.4.10-MariaDB-1:10.4.10+maria~bionic", ServerTypeMariaDB, mkVer(10, 4, 10, "MariaDB-1")},
 		{3, "5.7.25-TiDB-v4.0.0-alpha-1263-g635f2e1af", ServerTypeTiDB, mkVer(4, 0, 0, "alpha-1263-g635f2e1af")},
 		{4, "5.7.25-TiDB-v3.0.7-58-g6adce2367", ServerTypeTiDB, mkVer(3, 0, 7, "58-g6adce2367")},
-		{5, "invalid version", ServerTypeUnknown, (*semver.Version)(nil)},
+		{5, "5.7.25-TiDB-3.0.6", ServerTypeTiDB, mkVer(3, 0, 6, "")},
+		{6, "invalid version", ServerTypeUnknown, (*semver.Version)(nil)},
 	}
 	dec := func(d []interface{}) (tag int, verStr string, tp ServerType, v *semver.Version) {
 		return d[0].(int), d[1].(string), ServerType(d[2].(int)), d[3].(*semver.Version)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Compatible with the old version of tidb client that does not have the prefix 'v' on version info.
我用的3.0.6版本的tidb，执行时会出现以下的panic报错，原因是版本检查的正则表达式默认以'v'为前缀，而3.0.6版本没有'v'前缀

Git commit hash: 0175843056a6068dd2f64afca6277d890934b63c
Git branch:      master
Build timestamp: 2020-06-08 02:26:25Z
Go version:      go version go1.13.4 linux/amd64

[2020/11/04 15:28:55.932 +08:00] [DEBUG] [config.go:105] ["parse server info"] ["server info string"=5.7.25-TiDB-3.0.6]
[2020/11/04 15:28:55.932 +08:00] [INFO] [config.go:118] ["detect server type"] [type=TiDB]
panic: runtime error: slice bounds out of range [1:0]

goroutine 1 [running]:
github.com/pingcap/dumpling/v4/export.ParseServerInfo(0xc000136060, 0x11, 0x11, 0x0)
 /home/pingcap/goPath/src/github.com/pingcap/dumpling/v4/export/config.go:123 +0x8ba
github.com/pingcap/dumpling/v4/export.detectServerInfo(0xc0001b6000, 0x5, 0xc00015e680, 0x35, 0xc0001b6000)
 /home/pingcap/goPath/src/github.com/pingcap/dumpling/v4/export/prepare.go:38 +0x81
github.com/pingcap/dumpling/v4/export.Dump(0xc0000c2300, 0x0, 0x0)
 /home/pingcap/goPath/src/github.com/pingcap/dumpling/v4/export/dump.go:35 +0x2cb
main.main()
 /home/pingcap/goPath/src/github.com/pingcap/dumpling/cmd/dumpling/main.go:172 +0x106a

### What is changed and how it works?
works fine

### Check List 

Tests
 - No code

Side effects
 - Breaking backward compatibility

Related changes
 - Need to cherry-pick to the release branch
 
### Release note
- No release note

Signed-off-by: Cuixiaotian cxt90730@126.com