### PR TITLE
hotfix the bug that -T can't work which is introduced from #194

### DIFF
--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -446,7 +446,7 @@ func ParseTableFilter(tablesList, filters []string) (filter.Filter, error) {
 	}
 
 	// only parse -T when -f is default value. otherwise bail out.
-	if !(len(filters) == 2 && filters[0] == "*.*" && filters[1] == DefaultTableFilter) {
+	if !sameStringArray(filters, []string{"*.*", DefaultTableFilter}) {
 		return nil, errors.New("cannot pass --tables-list and --filter together")
 	}
 

--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -446,7 +446,7 @@ func ParseTableFilter(tablesList, filters []string) (filter.Filter, error) {
 	}
 
 	// only parse -T when -f is default value. otherwise bail out.
-	if len(filters) != 1 || filters[0] != "*.*" {
+	if !(len(filters) == 2 && filters[0] == "*.*" && filters[1] == DefaultTableFilter) {
 		return nil, errors.New("cannot pass --tables-list and --filter together")
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/pingcap/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md

You can use it with query parameters: https://github.com/pingcap/dumpling/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
```log
./bin/dumpling -h xx -P yy -u root -T A.B
Release version: v4.0.8-9-g7633719
Git commit hash: 763371960a2ba2ae242d4557e887425f9a3c29cb
Git branch:      master
Build timestamp: 2020-11-09 09:53:49Z
Go version:      go version go1.13.4 darwin/amd64


parse arguments failed: failed to parse filter: cannot pass --tables-list and --filter together
github.com/pingcap/dumpling/v4/export.(*Config).ParseFromFlags
        /Users/chauncy/code/goPath/src/github.com/pingcap/dumpling/v4/export/config.go:396
main.main
        /Users/chauncy/code/goPath/src/github.com/pingcap/dumpling/cmd/dumpling/main.go:49
runtime.main
        /usr/local/go/src/runtime/proc.go:203
runtime.goexit
        /usr/local/go/src/runtime/asm_amd64.s:1357
```

### What is changed and how it works?
Update the check rule for `--filter` argument.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
  Work well in this PR.

Related changes

 - Need to cherry-pick to the release branch
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
- No release note