### PR TITLE
set --help exit code to zero

### DIFF
--- a/cmd/dumpling/main.go
+++ b/cmd/dumpling/main.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	_ "net/http/pprof"
 	"os"
@@ -33,14 +32,19 @@ func main() {
 		fmt.Fprint(os.Stderr, "Dumpling is a CLI tool that helps you dump MySQL/TiDB data\n\nUsage:\n  dumpling [flags]\n\nFlags:\n")
 		pflag.PrintDefaults()
 	}
-	pflag.ErrHelp = errors.New("")
-
 	printVersion := pflag.BoolP("version", "V", false, "Print Dumpling version")
 
 	conf := export.DefaultConfig()
 	conf.DefineFlags(pflag.CommandLine)
 
 	pflag.Parse()
+	if printHelp, err := pflag.CommandLine.GetBool(export.FlagHelp); printHelp || err != nil {
+		if err != nil {
+			fmt.Printf("\nGet help flag error: %s\n", err)
+		}
+		pflag.Usage()
+		return
+	}
 	println(cli.LongVersion())
 	if *printVersion {
 		return

--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -221,7 +221,7 @@ func (conf *Config) DefineFlags(flags *pflag.FlagSet) {
 	flags.String(flagOutputFilenameTemplate, "", "The output filename template (without file extension)")
 	flags.Bool(flagCompleteInsert, false, "Use complete INSERT statements that include column names")
 	flags.StringToString(flagParams, nil, `Extra session variables used while dumping, accepted format: --params "character_set_client=latin1,character_set_connection=latin1"`)
-	flags.Bool(FlagHelp, false, "Whether to print help message and quit")
+	flags.Bool(FlagHelp, false, "Print help message and quit")
 }
 
 // GetDSN generates DSN from Config

--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -62,6 +62,7 @@ const (
 	flagOutputFilenameTemplate  = "output-filename-template"
 	flagCompleteInsert          = "complete-insert"
 	flagParams                  = "params"
+	FlagHelp                    = "help"
 )
 
 type Config struct {
@@ -220,6 +221,7 @@ func (conf *Config) DefineFlags(flags *pflag.FlagSet) {
 	flags.String(flagOutputFilenameTemplate, "", "The output filename template (without file extension)")
 	flags.Bool(flagCompleteInsert, false, "Use complete INSERT statements that include column names")
 	flags.StringToString(flagParams, nil, `Extra session variables used while dumping, accepted format: --params "character_set_client=latin1,character_set_connection=latin1"`)
+	flags.Bool(FlagHelp, false, "Whether to print help message and quit")
 }
 
 // GetDSN generates DSN from Config


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/pingcap/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md

You can use it with query parameters: https://github.com/pingcap/dumpling/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Currently, dumpling exit relys on `pflag.ErrHelp`. The exit code will be 2 for dumpling.

### What is changed and how it works?
Add `FlagHelp` to avoid exiting with code 2. This can also help dm avoid quitted when some user mistakenly set `--help` in `ExtraArgs`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
```bash
$ ./bin/dumpling --help
Dumpling is a CLI tool that helps you dump MySQL/TiDB data

Usage:
  dumpling [flags]

Flags:
      --allow-cleartext-passwords         Allow passwords to be sent in cleartext (warning: don't use without TLS)
      --ca string                         The path name to the certificate authority file for TLS connection
      --case-sensitive                    whether the filter should be case-sensitive
      --cert string                       The path name to the client certificate file for TLS connection
      --complete-insert                   Use complete INSERT statements that include column names
      --consistency string                Consistency level during dumping: {auto|none|flush|lock|snapshot} (default "auto")
      --csv-delimiter string              The delimiter for values in csv files, default '"' (default "\"")
      --csv-null-value string             The null value used when export to csv (default "\\N")
      --csv-separator string              The separator for csv files, default ',' (default ",")
  -B, --database strings                  Databases to dump
      --dump-empty-database               whether to dump empty database (default true)
      --escape-backslash                  use backslash to escape special characters (default true)
  -F, --filesize string                   The approximate size of output file
      --filetype string                   The type of export file (sql/csv) (default "sql")
  -f, --filter strings                    filter to select which tables to dump (default [*.*,!/^(mysql|sys|INFORMATION_SCHEMA|PERFORMANCE_SCHEMA|METRICS_SCHEMA|INSPECTION_SCHEMA)$/.*])
      --gcs.credentials-file string       (experimental) Set the GCS credentials file path
      --gcs.endpoint string               (experimental) Set the GCS endpoint URL
      --gcs.predefined-acl string         (experimental) Specify the GCS predefined acl for objects
      --gcs.storage-class string          (experimental) Specify the GCS storage class for objects
      --help                              Whether to print help message and quit
  -h, --host string                       The host to connect to (default "127.0.0.1")
      --key string                        The path name to the client private key file for TLS connection
  -L, --logfile path                      Log file path, leave empty to write to console
      --logfmt format                     Log format: {text|json} (default "text")
      --loglevel string                   Log level: {debug|info|warn|error|dpanic|panic|fatal} (default "info")
  -d, --no-data                           Do not dump table data
      --no-header                         whether not to dump CSV table header
  -m, --no-schemas                        Do not dump table schemas with the data
  -W, --no-views                          Do not dump views (default true)
  -o, --output string                     Output directory (default "./export-2020-11-10T11:39:47+08:00")
      --output-filename-template string   The output filename template (without file extension)
      --params stringToString             Extra session variables used while dumping, accepted format: --params "character_set_client=latin1,character_set_connection=latin1" (default [])
  -p, --password string                   User password
  -P, --port int                          TCP/IP port to connect to (default 4000)
  -r, --rows uint                         Split table into chunks of this many rows, default unlimited
      --s3.acl string                     (experimental) Set the S3 canned ACLs, e.g. authenticated-read
      --s3.endpoint string                (experimental) Set the S3 endpoint URL, please specify the http or https scheme explicitly
      --s3.provider string                (experimental) Set the S3 provider, e.g. aws, alibaba, ceph
      --s3.region string                  (experimental) Set the S3 region, e.g. us-east-1
      --s3.sse string                     Set S3 server-side encryption, e.g. aws:kms
      --s3.sse-kms-key-id string          KMS CMK key id to use with S3 server-side encryption.Leave empty to use S3 owned key.
      --s3.storage-class string           (experimental) Set the S3 storage class, e.g. STANDARD
      --snapshot string                   Snapshot position (uint64 from pd timestamp for TiDB). Valid only when consistency=snapshot
  -S, --sql string                        Dump data with given sql. This argument doesn't support concurrent dump
  -s, --statement-size uint               Attempted size of INSERT statement in bytes (default 1000000)
      --status-addr string                dumpling API server and pprof addr (default ":8281")
  -T, --tables-list strings               Comma delimited table list to dump; must be qualified table names
  -t, --threads int                       Number of goroutines to use, default 4 (default 4)
      --tidb-mem-quota-query uint         The maximum memory limit for a single SQL statement, in bytes. Default: 32GB (default 34359738368)
  -u, --user string                       Username with privileges to run the dump (default "root")
  -V, --version                           Print Dumpling version
      --where string                      Dump only selected records
$ echo $?
0
```

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
- No release note
