### PR TITLE
rebuild mysql conn when retry failed chunks and support `trx-consistency-only` parameter

### DIFF
--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -138,7 +138,7 @@ func DefaultConfig() *Config {
 		SortByPk:           true,
 		Tables:             nil,
 		Snapshot:           "",
-		Consistency:        "auto",
+		Consistency:        consistencyTypeAuto,
 		NoViews:            true,
 		Rows:               UnspecifiedSize,
 		Where:              "",
@@ -196,7 +196,7 @@ func (conf *Config) DefineFlags(flags *pflag.FlagSet) {
 	flags.String(flagLoglevel, "info", "Log level: {debug|info|warn|error|dpanic|panic|fatal}")
 	flags.StringP(flagLogfile, "L", "", "Log file `path`, leave empty to write to console")
 	flags.String(flagLogfmt, "text", "Log `format`: {text|json}")
-	flags.String(flagConsistency, "auto", "Consistency level during dumping: {auto|none|flush|lock|snapshot}")
+	flags.String(flagConsistency, consistencyTypeAuto, "Consistency level during dumping: {auto|none|flush|lock|snapshot}")
 	flags.String(flagSnapshot, "", "Snapshot position (uint64 from pd timestamp for TiDB). Valid only when consistency=snapshot")
 	flags.BoolP(flagNoViews, "W", true, "Do not dump views")
 	flags.String(flagStatusAddr, ":8281", "dumpling API server and pprof addr")

--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -23,47 +23,47 @@ import (
 )
 
 const (
-	flagDatabase                = "database"
-	flagTablesList              = "tables-list"
-	flagHost                    = "host"
-	flagUser                    = "user"
-	flagPort                    = "port"
-	flagPassword                = "password"
-	flagAllowCleartextPasswords = "allow-cleartext-passwords"
-	flagThreads                 = "threads"
-	flagFilesize                = "filesize"
-	flagStatementSize           = "statement-size"
-	flagOutput                  = "output"
-	flagLoglevel                = "loglevel"
-	flagLogfile                 = "logfile"
-	flagLogfmt                  = "logfmt"
-	flagConsistency             = "consistency"
-	flagSnapshot                = "snapshot"
-	flagNoViews                 = "no-views"
-	flagStatusAddr              = "status-addr"
-	flagRows                    = "rows"
-	flagWhere                   = "where"
-	flagEscapeBackslash         = "escape-backslash"
-	flagFiletype                = "filetype"
-	flagNoHeader                = "no-header"
-	flagNoSchemas               = "no-schemas"
-	flagNoData                  = "no-data"
-	flagCsvNullValue            = "csv-null-value"
-	flagSql                     = "sql"
-	flagFilter                  = "filter"
-	flagCaseSensitive           = "case-sensitive"
-	flagDumpEmptyDatabase       = "dump-empty-database"
-	flagTidbMemQuotaQuery       = "tidb-mem-quota-query"
-	flagCA                      = "ca"
-	flagCert                    = "cert"
-	flagKey                     = "key"
-	flagCsvSeparator            = "csv-separator"
-	flagCsvDelimiter            = "csv-delimiter"
-	flagOutputFilenameTemplate  = "output-filename-template"
-	flagCompleteInsert          = "complete-insert"
-	flagParams                  = "params"
-	flagReadTimeout             = "read-timeout"
-	flagTrxConsistencyOnly      = "trx-consistency-only"
+	flagDatabase                 = "database"
+	flagTablesList               = "tables-list"
+	flagHost                     = "host"
+	flagUser                     = "user"
+	flagPort                     = "port"
+	flagPassword                 = "password"
+	flagAllowCleartextPasswords  = "allow-cleartext-passwords"
+	flagThreads                  = "threads"
+	flagFilesize                 = "filesize"
+	flagStatementSize            = "statement-size"
+	flagOutput                   = "output"
+	flagLoglevel                 = "loglevel"
+	flagLogfile                  = "logfile"
+	flagLogfmt                   = "logfmt"
+	flagConsistency              = "consistency"
+	flagSnapshot                 = "snapshot"
+	flagNoViews                  = "no-views"
+	flagStatusAddr               = "status-addr"
+	flagRows                     = "rows"
+	flagWhere                    = "where"
+	flagEscapeBackslash          = "escape-backslash"
+	flagFiletype                 = "filetype"
+	flagNoHeader                 = "no-header"
+	flagNoSchemas                = "no-schemas"
+	flagNoData                   = "no-data"
+	flagCsvNullValue             = "csv-null-value"
+	flagSql                      = "sql"
+	flagFilter                   = "filter"
+	flagCaseSensitive            = "case-sensitive"
+	flagDumpEmptyDatabase        = "dump-empty-database"
+	flagTidbMemQuotaQuery        = "tidb-mem-quota-query"
+	flagCA                       = "ca"
+	flagCert                     = "cert"
+	flagKey                      = "key"
+	flagCsvSeparator             = "csv-separator"
+	flagCsvDelimiter             = "csv-delimiter"
+	flagOutputFilenameTemplate   = "output-filename-template"
+	flagCompleteInsert           = "complete-insert"
+	flagParams                   = "params"
+	flagReadTimeout              = "read-timeout"
+	flagTransactionalConsistency = "transactional-consistency"
 
 	FlagHelp = "help"
 )
@@ -109,16 +109,16 @@ type Config struct {
 	CsvDelimiter  string
 	ReadTimeout   time.Duration
 
-	TableFilter        filter.Filter `json:"-"`
-	Rows               uint64
-	Where              string
-	FileType           string
-	CompleteInsert     bool
-	TrxConsistencyOnly bool
-	EscapeBackslash    bool
-	DumpEmptyDatabase  bool
-	OutputFileTemplate *template.Template `json:"-"`
-	SessionParams      map[string]interface{}
+	TableFilter              filter.Filter `json:"-"`
+	Rows                     uint64
+	Where                    string
+	FileType                 string
+	CompleteInsert           bool
+	TransactionalConsistency bool
+	EscapeBackslash          bool
+	DumpEmptyDatabase        bool
+	OutputFileTemplate       *template.Template `json:"-"`
+	SessionParams            map[string]interface{}
 
 	PosAfterConnect bool
 
@@ -232,7 +232,7 @@ func (conf *Config) DefineFlags(flags *pflag.FlagSet) {
 	flags.Bool(FlagHelp, false, "Print help message and quit")
 	flags.Duration(flagReadTimeout, 15*time.Minute, "I/O read timeout for db connection.")
 	flags.MarkHidden(flagReadTimeout)
-	flags.Bool(flagTrxConsistencyOnly, true, "Only support transactional consistency")
+	flags.Bool(flagTransactionalConsistency, true, "Only support transactional consistency")
 }
 
 // GetDSN generates DSN from Config
@@ -370,7 +370,7 @@ func (conf *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	conf.TrxConsistencyOnly, err = flags.GetBool(flagTrxConsistencyOnly)
+	conf.TransactionalConsistency, err = flags.GetBool(flagTransactionalConsistency)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -62,7 +62,9 @@ const (
 	flagOutputFilenameTemplate  = "output-filename-template"
 	flagCompleteInsert          = "complete-insert"
 	flagParams                  = "params"
-	FlagHelp                    = "help"
+	flagTrxConsistencyOnly      = "trx-consistency-only"
+
+	FlagHelp = "help"
 )
 
 type Config struct {
@@ -110,6 +112,7 @@ type Config struct {
 	Where              string
 	FileType           string
 	CompleteInsert     bool
+	TrxConsistencyOnly bool
 	EscapeBackslash    bool
 	DumpEmptyDatabase  bool
 	OutputFileTemplate *template.Template `json:"-"`
@@ -222,6 +225,7 @@ func (conf *Config) DefineFlags(flags *pflag.FlagSet) {
 	flags.Bool(flagCompleteInsert, false, "Use complete INSERT statements that include column names")
 	flags.StringToString(flagParams, nil, `Extra session variables used while dumping, accepted format: --params "character_set_client=latin1,character_set_connection=latin1"`)
 	flags.Bool(FlagHelp, false, "Print help message and quit")
+	flags.Bool(flagTrxConsistencyOnly, true, "Only support transactional consistency")
 }
 
 // GetDSN generates DSN from Config
@@ -352,6 +356,10 @@ func (conf *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 		return errors.Trace(err)
 	}
 	conf.CompleteInsert, err = flags.GetBool(flagCompleteInsert)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	conf.TrxConsistencyOnly, err = flags.GetBool(flagTrxConsistencyOnly)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/v4/export/consistency.go
+++ b/v4/export/consistency.go
@@ -89,7 +89,7 @@ func (c *ConsistencyFlushTableWithReadLock) TearDown(ctx context.Context) error 
 
 func (c *ConsistencyFlushTableWithReadLock) PingContext(ctx context.Context) error {
 	if c.conn == nil {
-		return errors.New("connection has already closed!")
+		return errors.New("consistency connection has already been closed!")
 	}
 	return c.conn.PingContext(ctx)
 }
@@ -124,7 +124,7 @@ func (c *ConsistencyLockDumpingTables) TearDown(ctx context.Context) error {
 
 func (c *ConsistencyLockDumpingTables) PingContext(ctx context.Context) error {
 	if c.conn == nil {
-		return errors.New("connection has already closed!")
+		return errors.New("consistency connection has already been closed!")
 	}
 	return c.conn.PingContext(ctx)
 }

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -76,7 +76,7 @@ func Dump(pCtx context.Context, conf *Config) (err error) {
 	}
 
 	snapshot := conf.Snapshot
-	if snapshot == "" && (doPdGC || conf.Consistency == consistencyTypeLock) {
+	if snapshot == "" && (doPdGC || conf.Consistency == consistencyTypeSnapshot) {
 		conn, err := pool.Conn(ctx)
 		if err != nil {
 			conn.Close()
@@ -97,7 +97,7 @@ func Dump(pCtx context.Context, conf *Config) (err error) {
 		if err != nil {
 			return err
 		}
-		if conf.Consistency == consistencyTypeLock {
+		if conf.Consistency == consistencyTypeSnapshot {
 			hasTiKV, err := CheckTiDBWithTiKV(pool)
 			if err != nil {
 				return err
@@ -240,7 +240,7 @@ func Dump(pCtx context.Context, conf *Config) (err error) {
 				return conn, err
 			}
 			conn = newConn
-			// renew the master status after connection. dm can't close safe-mode until current pos
+			// renew the master status after connection. dm can't close safe-mode until dm reaches current pos
 			if conf.PosAfterConnect {
 				err = m.recordGlobalMetaData(conn, conf.ServerInfo.ServerType, true)
 				if err != nil {

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -201,7 +201,7 @@ func Dump(pCtx context.Context, conf *Config) (err error) {
 		}
 	}
 
-	if conf.TrxConsistencyOnly {
+	if conf.TransactionalConsistency {
 		if conf.Consistency == consistencyTypeFlush || conf.Consistency == consistencyTypeLock {
 			log.Info("All the dumping transactions have started. Start to unlock tables")
 		}
@@ -309,7 +309,7 @@ func dumpDatabases(pCtx context.Context, conf *Config, connectPool *connectionsP
 							return
 						}
 						return writer.WriteTableData(ctx, tableIR)
-					}, newDumpChunkBackoffer(canRebuildConn(conf.Consistency, conf.TrxConsistencyOnly)))
+					}, newDumpChunkBackoffer(canRebuildConn(conf.Consistency, conf.TransactionalConsistency)))
 				})
 			}
 		}

--- a/v4/export/dump_test.go
+++ b/v4/export/dump_test.go
@@ -83,7 +83,9 @@ func (s *testDumpSuite) TestDumpDatabase(c *C) {
 
 	mockWriter := newMockWriter()
 	connectPool := newMockConnectPool(c, db)
-	err = dumpDatabases(context.Background(), mockConfig, connectPool, mockWriter)
+	err = dumpDatabases(context.Background(), mockConfig, connectPool, mockWriter, func(conn *sql.Conn) (*sql.Conn, error) {
+		return conn, nil
+	})
 	c.Assert(err, IsNil)
 
 	c.Assert(len(mockWriter.databaseMeta), Equals, 1)
@@ -202,6 +204,7 @@ func (s *testDumpSuite) TestDumpDatabaseWithRetry(c *C) {
 	mockConfig.SortByPk = false
 	mockConfig.Databases = []string{"test"}
 	mockConfig.Tables = NewDatabaseTables().AppendTables("test", "t")
+	mockConfig.Consistency = "none"
 	db, mock, err := sqlmock.New()
 	c.Assert(err, IsNil)
 
@@ -221,7 +224,9 @@ func (s *testDumpSuite) TestDumpDatabaseWithRetry(c *C) {
 
 	mockWriter := newMockWriter()
 	connectPool := newMockConnectPool(c, db)
-	err = dumpDatabases(context.Background(), mockConfig, connectPool, mockWriter)
+	err = dumpDatabases(context.Background(), mockConfig, connectPool, mockWriter, func(conn *sql.Conn) (*sql.Conn, error) {
+		return conn, nil
+	})
 	c.Assert(err, IsNil)
 
 	c.Assert(len(mockWriter.databaseMeta), Equals, 1)

--- a/v4/export/dump_test.go
+++ b/v4/export/dump_test.go
@@ -204,7 +204,7 @@ func (s *testDumpSuite) TestDumpDatabaseWithRetry(c *C) {
 	mockConfig.SortByPk = false
 	mockConfig.Databases = []string{"test"}
 	mockConfig.Tables = NewDatabaseTables().AppendTables("test", "t")
-	mockConfig.Consistency = "none"
+	mockConfig.Consistency = consistencyTypeNone
 	db, mock, err := sqlmock.New()
 	c.Assert(err, IsNil)
 

--- a/v4/export/retry.go
+++ b/v4/export/retry.go
@@ -14,7 +14,12 @@ const (
 	dumpChunkMaxWaitInterval = 200 * time.Millisecond
 )
 
-func newDumpChunkBackoffer() *dumpChunkBackoffer {
+func newDumpChunkBackoffer(canRetry bool) *dumpChunkBackoffer {
+	if !canRetry {
+		return &dumpChunkBackoffer{
+			attempt: 1,
+		}
+	}
 	return &dumpChunkBackoffer{
 		attempt:      dumpChunkRetryTime,
 		delayTime:    dumpChunkWaitInterval,

--- a/v4/export/writer_util.go
+++ b/v4/export/writer_util.go
@@ -313,6 +313,7 @@ func WriteInsertInCsv(pCtx context.Context, tblIR TableDataIR, w storage.Writer,
 
 	log.Debug("dumping table",
 		zap.String("table", tblIR.TableName()),
+		zap.Int("chunkIndex", tblIR.ChunkIndex()),
 		zap.Int("record counts", counter))
 	if bf.Len() > 0 {
 		wp.input <- bf


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/pingcap/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md

You can use it with query parameters: https://github.com/pingcap/dumpling/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/dumpling/issues/178
When we retry on failed chunks, if mysql connection is broken, the retry will fail directly and will take no effect.

### What is changed and how it works?
1. Add `trx-consistency-only` option. The default value is true. If it is `false`, dumpling won't release locks until the dumping progress is finished.
2. When dumpling retrys on failed chunks, we should rebuild MySQL connection when it was broken.
* For consistency none and consistency snapshot, we can rebuild MySQL connection directly since it doesn't assure consistent snapshot. But for consistency none we should update metadata after conn for DM when we build new MySQL conn.
* For consistency flush and consistency lock, we can rebuild MySQL connection only when dumpling hold locks during the whole dumping progress (`trx-consistency-only` = false). Before rebuilding MySQL connection we should also check that whether the mysql lock connection is still alive.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
    Test kill the socket mysql connection. The connection can be rebuilt and dump data correctly.

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
- Support `trx-consistency-only` parameter and support rebuild mysql connections during retry.