### PR TITLE
writer_util: fix csv format performance bug

### DIFF
--- a/v4/export/writer_util.go
+++ b/v4/export/writer_util.go
@@ -294,10 +294,11 @@ func WriteInsertInCsv(pCtx context.Context, tblIR TableDataIR, w storage.Writer,
 		counter         uint64
 		lastCounter     uint64
 		escapeBackSlash = tblIR.EscapeBackSlash()
+		selectedFields  = tblIR.SelectedField()
 		err             error
 	)
 
-	if !cfg.NoHeader && len(tblIR.ColumnNames()) != 0 && tblIR.SelectedField() != "" {
+	if !cfg.NoHeader && len(tblIR.ColumnNames()) != 0 && selectedFields != "" {
 		for i, col := range tblIR.ColumnNames() {
 			bf.Write(opt.delimiter)
 			escape([]byte(col), bf, getEscapeQuotation(escapeBackSlash, opt.delimiter))
@@ -312,7 +313,7 @@ func WriteInsertInCsv(pCtx context.Context, tblIR TableDataIR, w storage.Writer,
 
 	for fileRowIter.HasNext() {
 		lastBfSize := bf.Len()
-		if tblIR.SelectedField() != "" {
+		if selectedFields != "" {
 			if err = fileRowIter.Decode(row); err != nil {
 				log.Error("scanning from sql.Row failed", zap.Error(err))
 				return err


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/pingcap/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md

You can use it with query parameters: https://github.com/pingcap/dumpling/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When dumpling dumps tables in CSV formats through `--sql` or `-T`, the performance has a big difference.
After analyzing dumpling will waste a lot of time at `fmt.Sprintf`. However, `selected` is fixed for a `tableIR`.
Flame graph:
![image](https://user-images.githubusercontent.com/21104942/100994261-5f47c080-3591-11eb-8bb6-43869b7b9933.png)

### What is changed and how it works?
Replace `tblIR.SelectedField()` with `selectedFields`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
Performance comparison(20G tpcc data, one thread):
Before:
real    3m2.199s
user    3m28.472s
sys     0m43.862s
After:
real    2m35.890s
user    2m52.984s
sys     0m42.854s


Related changes

 - Need to cherry-pick to the release branch
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
- fix csv format performance bug