### PR TITLE
*: refine dumpling log hint system

### DIFF
--- a/cmd/dumpling/main.go
+++ b/cmd/dumpling/main.go
@@ -56,6 +56,10 @@ func main() {
 		fmt.Printf("\nparse arguments failed: %+v\n", err)
 		os.Exit(1)
 	}
+	if pflag.NArg() > 0 {
+		fmt.Printf("\nmeet some unparsed arguments, please check again: %+v\n", pflag.Args())
+		os.Exit(1)
+	}
 
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pingcap/log v0.0.0-20200828042413-fce0951f1463
 	github.com/pingcap/tidb-tools v4.0.8-0.20200927084250-e47e0e12c7f3+incompatible
 	github.com/prometheus/client_golang v1.5.1
+	github.com/prometheus/client_model v0.2.0
 	github.com/soheilhy/cmux v0.1.4
 	github.com/spf13/pflag v1.0.5
 	github.com/tikv/pd v1.1.0-beta.0.20200910042021-254d1345be09

--- a/v4/export/block_allow_list.go
+++ b/v4/export/block_allow_list.go
@@ -31,7 +31,7 @@ func filterTables(conf *Config) {
 	}
 
 	if len(ignoredDBTable) > 0 {
-		log.Debug("ignore table", zap.String("", ignoredDBTable.Literal()))
+		log.Debug("ignore table", zap.String("tables", ignoredDBTable.Literal()))
 	}
 
 	conf.Tables = dbTables

--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -173,7 +173,7 @@ func DefaultConfig() *Config {
 func (conf *Config) String() string {
 	cfg, err := json.Marshal(conf)
 	if err != nil {
-		log.Error("marshal config to json", zap.Error(err))
+		log.Error("fail to marshal config to json", zap.Error(err))
 	}
 	return string(cfg)
 }

--- a/v4/export/http_handler.go
+++ b/v4/export/http_handler.go
@@ -35,7 +35,7 @@ func startHTTPServer(lis net.Listener) {
 	err := httpServer.Serve(lis)
 	err = errors.Cause(err)
 	if err != nil && !isErrNetClosing(err) && err != http.ErrServerClosed {
-		log.Error("http server return with error", zap.Error(err))
+		log.Warn("http server return with error", zap.Error(err))
 	}
 }
 

--- a/v4/export/status.go
+++ b/v4/export/status.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/docker/go-units"
 	"go.uber.org/zap"
 
 	"github.com/pingcap/dumpling/v4/log"
@@ -37,7 +38,7 @@ func (d *Dumper) runLogProgress(ctx context.Context) {
 			log.Info("progress",
 				zap.String("tables", fmt.Sprintf("%.0f/%.0f (%.1f%%)", completedTables, totalTables, completedTables/totalTables*100)),
 				zap.String("finished rows", fmt.Sprintf("%.0f", finishedRows)),
-				zap.String("finished bytes", fmt.Sprintf("%.0f", finishedBytes)),
+				zap.String("finished size", units.HumanSize(finishedBytes)),
 				zap.Float64("speed(MiB/s)", (finishedBytes-lastBytes)/(1048576e-9*nanoseconds)),
 			)
 

--- a/v4/export/status.go
+++ b/v4/export/status.go
@@ -1,0 +1,60 @@
+// Copyright 2020 PingCAP, Inc. Licensed under Apache-2.0.
+
+package export
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/pingcap/dumpling/v4/log"
+)
+
+const logProgressTick = 2 * time.Minute
+
+func (d *Dumper) runLogProgress(ctx context.Context) {
+	conf := d.conf
+	totalTables := float64(calculateTableCount(conf.Tables))
+	logProgressTicker := time.NewTicker(logProgressTick)
+	lastCheckpoint := time.Now()
+	lastBytes := float64(0)
+	defer logProgressTicker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			log.Debug("stopping log progress")
+			return
+		case <-logProgressTicker.C:
+			nanoseconds := float64(time.Since(lastCheckpoint).Nanoseconds())
+
+			completedTables := ReadCounter(finishedTablesCounter.With(conf.Labels))
+			finishedBytes := ReadCounter(finishedSizeCounter.With(conf.Labels))
+			finishedRows := ReadCounter(finishedRowsCounter.With(conf.Labels))
+
+			// Note: a speed of 28 MiB/s roughly corresponds to 100 GiB/hour.
+			log.Info("progress",
+				zap.String("tables", fmt.Sprintf("%.0f/%.0f (%.1f%%)", completedTables, totalTables, completedTables/totalTables*100)),
+				zap.String("finished rows", fmt.Sprintf("%.0f", finishedRows)),
+				zap.String("finished bytes", fmt.Sprintf("%.0f", finishedBytes)),
+				zap.Float64("speed(MiB/s)", (finishedBytes-lastBytes)/(1048576e-9*nanoseconds)),
+			)
+
+			lastCheckpoint = time.Now()
+			lastBytes = finishedBytes
+		}
+	}
+}
+
+func calculateTableCount(m DatabaseTables) int {
+	cnt := 0
+	for _, tables := range m {
+		for _, table := range tables {
+			if table.Type == TableTypeBase {
+				cnt++
+			}
+		}
+	}
+	return cnt
+}

--- a/v4/export/status.go
+++ b/v4/export/status.go
@@ -34,7 +34,6 @@ func (d *Dumper) runLogProgress(ctx context.Context) {
 			finishedBytes := ReadCounter(finishedSizeCounter.With(conf.Labels))
 			finishedRows := ReadCounter(finishedRowsCounter.With(conf.Labels))
 
-			// Note: a speed of 28 MiB/s roughly corresponds to 100 GiB/hour.
 			log.Info("progress",
 				zap.String("tables", fmt.Sprintf("%.0f/%.0f (%.1f%%)", completedTables, totalTables, completedTables/totalTables*100)),
 				zap.String("finished rows", fmt.Sprintf("%.0f", finishedRows)),

--- a/v4/export/writer.go
+++ b/v4/export/writer.go
@@ -171,6 +171,7 @@ func (w *Writer) WriteTableData(meta TableMeta, ir TableDataIR, currentChunk int
 		// don't rebuild connection when dump for the first time
 		if retryTime > 1 {
 			conn, err = w.rebuildConnFn(conn)
+			w.conn = conn
 			if err != nil {
 				return
 			}

--- a/v4/export/writer_util.go
+++ b/v4/export/writer_util.go
@@ -174,7 +174,7 @@ func WriteInsert(pCtx context.Context, cfg *Config, meta TableMeta, tblIR TableD
 		row                   = MakeRowReceiver(meta.ColumnTypes())
 		counter               uint64
 		lastCounter           uint64
-		escapeBackSlash       = cfg.EscapeBackslash
+		escapeBackslash       = cfg.EscapeBackslash
 		err                   error
 	)
 
@@ -199,10 +199,10 @@ func WriteInsert(pCtx context.Context, cfg *Config, meta TableMeta, tblIR TableD
 			lastBfSize := bf.Len()
 			if selectedField != "" {
 				if err = fileRowIter.Decode(row); err != nil {
-					log.Error("scanning from sql.Row failed", zap.Error(err))
+					log.Error("fail to scan from sql.Row", zap.Error(err))
 					return errors.Trace(err)
 				}
-				row.WriteToBuffer(bf, escapeBackSlash)
+				row.WriteToBuffer(bf, escapeBackslash)
 			} else {
 				bf.WriteString("()")
 			}
@@ -243,9 +243,10 @@ func WriteInsert(pCtx context.Context, cfg *Config, meta TableMeta, tblIR TableD
 			break
 		}
 	}
-	log.Debug("dumping table",
+	log.Debug("finish dumping table(chunk)",
+		zap.String("database", meta.DatabaseName()),
 		zap.String("table", meta.TableName()),
-		zap.Uint64("record counts", counter))
+		zap.Uint64("total rows", counter))
 	if bf.Len() > 0 {
 		wp.input <- bf
 	}
@@ -295,7 +296,7 @@ func WriteInsertInCsv(pCtx context.Context, cfg *Config, meta TableMeta, tblIR T
 		row             = MakeRowReceiver(meta.ColumnTypes())
 		counter         uint64
 		lastCounter     uint64
-		escapeBackSlash = cfg.EscapeBackslash
+		escapeBackslash = cfg.EscapeBackslash
 		selectedFields  = meta.SelectedField()
 		err             error
 	)
@@ -303,7 +304,7 @@ func WriteInsertInCsv(pCtx context.Context, cfg *Config, meta TableMeta, tblIR T
 	if !cfg.NoHeader && len(meta.ColumnNames()) != 0 && selectedFields != "" {
 		for i, col := range meta.ColumnNames() {
 			bf.Write(opt.delimiter)
-			escapeCSV([]byte(col), bf, escapeBackSlash, opt)
+			escapeCSV([]byte(col), bf, escapeBackslash, opt)
 			bf.Write(opt.delimiter)
 			if i != len(meta.ColumnTypes())-1 {
 				bf.Write(opt.separator)
@@ -317,10 +318,10 @@ func WriteInsertInCsv(pCtx context.Context, cfg *Config, meta TableMeta, tblIR T
 		lastBfSize := bf.Len()
 		if selectedFields != "" {
 			if err = fileRowIter.Decode(row); err != nil {
-				log.Error("scanning from sql.Row failed", zap.Error(err))
+				log.Error("fail to scan from sql.Row", zap.Error(err))
 				return errors.Trace(err)
 			}
-			row.WriteToBufferInCsv(bf, escapeBackSlash, opt)
+			row.WriteToBufferInCsv(bf, escapeBackslash, opt)
 		}
 		counter++
 		wp.currentFileSize += uint64(bf.Len()-lastBfSize) + 1 // 1 is for "\n"
@@ -349,6 +350,7 @@ func WriteInsertInCsv(pCtx context.Context, cfg *Config, meta TableMeta, tblIR T
 	}
 
 	log.Debug("dumping table",
+		zap.String("database", meta.DatabaseName()),
 		zap.String("table", meta.TableName()),
 		zap.Uint64("record counts", counter))
 	if bf.Len() > 0 {

--- a/v4/export/writer_util.go
+++ b/v4/export/writer_util.go
@@ -349,10 +349,10 @@ func WriteInsertInCsv(pCtx context.Context, cfg *Config, meta TableMeta, tblIR T
 		}
 	}
 
-	log.Debug("dumping table",
+	log.Debug("finish dumping table(chunk)",
 		zap.String("database", meta.DatabaseName()),
 		zap.String("table", meta.TableName()),
-		zap.Uint64("record counts", counter))
+		zap.Uint64("total rows", counter))
 	if bf.Len() > 0 {
 		wp.input <- bf
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/pingcap/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md

You can use it with query parameters: https://github.com/pingcap/dumpling/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
1. close https://github.com/pingcap/dumpling/issues/225. Dumpling won't check unparsed arguments now. It's not easy for users to find spell errors.
2. https://github.com/pingcap/dumpling/issues/223. Some logs in dumpling are not clear enough. For example, we print the estimated count without table name. It's hard to debug.
3. Users can't get current dumpling work status and progress from logs now.

### What is changed and how it works?
1. Check unparsed arguments and return an error to users.
2. Refine dumpling's log info and adjust some log's level.
3. Add status printer in dumper.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
1. example for unparsed arguments:
```
$ ./bin/dumpling -P 4000 -T test.order_line -r 20 -F 10B where "id<5"
Release version: v4.0.8-31-gd75dc72
Git commit hash: d75dc721dd44902ea6fc72aafef88aad59977647
Git branch:      setWarnLog
Build timestamp: 2020-12-30 07:34:11Z
Go version:      go version go1.13.4 darwin/amd64

meet some unparsed arguments, please check again: [where id<5]
```
3. example for status printer:
```log
[2020/12/30 16:42:22.197 +08:00] [INFO] [status.go:37] [progress] [tables="0/1 (0.0%)"] ["finished rows"=42191631] ["finished size"=7.764GB] ["average speed(MiB/s)"=61.70014464561885]
[2020/12/30 16:44:22.197 +08:00] [INFO] [status.go:37] [progress] [tables="0/1 (0.0%)"] ["finished rows"=86052795] ["finished size"=15.83GB] ["average speed(MiB/s)"=64.1418352230345]
```

Related changes

 - Need to cherry-pick to the release branch
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->

- support check un-recognized arguments and print current progress during dumping