### PR TITLE
export: delete default tidb mem quota query configuration

### DIFF
--- a/tests/_utils/run_services
+++ b/tests/_utils/run_services
@@ -36,6 +36,7 @@ start_services() {
 
     cat > "$DUMPLING_TEST_DIR/tidb.toml" <<EOF
 port = 4000
+mem-quota-query = 1073741824
 [status]
 status-port = 10080
 [log.file]

--- a/tests/all_generate_column/conf/diff_config.toml
+++ b/tests/all_generate_column/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/basic/run.sh
+++ b/tests/basic/run.sh
@@ -52,3 +52,12 @@ run_dumpling --sql "select nextval(\`$DB_NAME\`.\`$SEQUENCE_NAME\`)"
 actual=$(grep -w "(.*)[,|;]" ${DUMPLING_OUTPUT_DIR}/result.000000000.sql | cut -c2-2)
 echo "expected 2, actual ${actual}"
 [ "$actual" = 2 ]
+
+# Test for tidb_mem_quota_query configuration
+export GO_FAILPOINTS="github.com/pingcap/dumpling/v4/export/PrintTiDBMemQuotaQuery=1*return"
+run_dumpling > ${DUMPLING_OUTPUT_DIR}/dumpling.log
+actual=`grep -w "tidb_mem_quota_query == 1073741824" ${DUMPLING_OUTPUT_DIR}/dumpling.log|wc -l`
+echo "expected 1, actual ${actual}"
+[ "$actual" = 1 ]
+
+export GO_FAILPOINTS=""

--- a/tests/e2e/conf/diff_config.toml
+++ b/tests/e2e/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/e2e_csv/conf/diff_config.toml
+++ b/tests/e2e_csv/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/ignore_generate_column/conf/diff_config.toml
+++ b/tests/ignore_generate_column/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/rows/conf/diff_config.toml
+++ b/tests/rows/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/tests/rows_extreme_int/conf/diff_config.toml
+++ b/tests/rows_extreme_int/conf/diff_config.toml
@@ -8,8 +8,6 @@ check-thread-count = 4
 
 sample-percent = 100
 
-use-rowid = false
-
 use-checksum = true
 
 fix-sql-file = "fix.sql"

--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -230,7 +230,7 @@ func (conf *Config) DefineFlags(flags *pflag.FlagSet) {
 	flags.StringSliceP(flagFilter, "f", []string{"*.*", DefaultTableFilter}, "filter to select which tables to dump")
 	flags.Bool(flagCaseSensitive, false, "whether the filter should be case-sensitive")
 	flags.Bool(flagDumpEmptyDatabase, true, "whether to dump empty database")
-	flags.Uint64(flagTidbMemQuotaQuery, UnspecifiedSize, "The maximum memory limit for a single SQL statement, in bytes. Default: 32GB")
+	flags.Uint64(flagTidbMemQuotaQuery, UnspecifiedSize, "The maximum memory limit for a single SQL statement, in bytes.")
 	flags.String(flagCA, "", "The path name to the certificate authority file for TLS connection")
 	flags.String(flagCert, "", "The path name to the client certificate file for TLS connection")
 	flags.String(flagKey, "", "The path name to the client private key file for TLS connection")

--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -230,7 +230,7 @@ func (conf *Config) DefineFlags(flags *pflag.FlagSet) {
 	flags.StringSliceP(flagFilter, "f", []string{"*.*", DefaultTableFilter}, "filter to select which tables to dump")
 	flags.Bool(flagCaseSensitive, false, "whether the filter should be case-sensitive")
 	flags.Bool(flagDumpEmptyDatabase, true, "whether to dump empty database")
-	flags.Uint64(flagTidbMemQuotaQuery, DefaultTiDBMemQuotaQuery, "The maximum memory limit for a single SQL statement, in bytes. Default: 32GB")
+	flags.Uint64(flagTidbMemQuotaQuery, UnspecifiedSize, "The maximum memory limit for a single SQL statement, in bytes. Default: 32GB")
 	flags.String(flagCA, "", "The path name to the certificate authority file for TLS connection")
 	flags.String(flagCert, "", "The path name to the client certificate file for TLS connection")
 	flags.String(flagKey, "", "The path name to the client private key file for TLS connection")
@@ -542,8 +542,6 @@ func (conf *Config) createExternalStorage(ctx context.Context) (storage.External
 const (
 	// UnspecifiedSize means the filesize/statement-size is unspecified
 	UnspecifiedSize = 0
-	// DefaultTiDBMemQuotaQuery is the default TiDBMemQuotaQuery size for TiDB
-	DefaultTiDBMemQuotaQuery = 32 << 30
 	// DefaultStatementSize is the default statement size
 	DefaultStatementSize = 1000000
 	// TiDBMemQuotaQueryName is the session variable TiDBMemQuotaQuery's name in TiDB

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -794,7 +794,7 @@ func setSessionParam(d *Dumper) error {
 	si := conf.ServerInfo
 	consistency, snapshot := conf.Consistency, conf.Snapshot
 	sessionParam := conf.SessionParams
-	if si.ServerType == ServerTypeTiDB {
+	if si.ServerType == ServerTypeTiDB && conf.TiDBMemQuotaQuery != UnspecifiedSize {
 		sessionParam[TiDBMemQuotaQueryName] = conf.TiDBMemQuotaQuery
 	}
 	if snapshot != "" {

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -196,6 +196,18 @@ func (d *Dumper) Dump() (dumpErr error) {
 	defer logProgressCancel()
 
 	tableDataStartTime := time.Now()
+
+	failpoint.Inject("PrintTiDBMemQuotaQuery", func(_ failpoint.Value) {
+		row := d.dbHandle.QueryRowContext(ctx, "select @@tidb_mem_quota_query;")
+		var s string
+		err = row.Scan(&s)
+		if err != nil {
+			fmt.Println(errors.Trace(err))
+		} else {
+			fmt.Printf("tidb_mem_quota_query == %s\n", s)
+		}
+	})
+
 	if conf.SQL == "" {
 		if err = d.dumpDatabases(metaConn, taskChan); err != nil {
 			return err


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/pingcap/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md

You can use it with query parameters: https://github.com/pingcap/dumpling/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/dumpling/issues/232
`dumpling`'s default `tidb-mem-quota-query` is 32GB which may cause TiDB OOM.

### What is changed and how it works?
Don't set `tidb-mem-quota-query` when it's not specified (Use TiDB's default configuration).

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

 - Possible performance regression

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
- Don't set tidb_mem_quota_query when it's not specified.
