### PR TITLE
fix the problem that dumpling panic when meeting an error at executing `--sql` 

### DIFF
--- a/v4/export/writer.go
+++ b/v4/export/writer.go
@@ -177,14 +177,14 @@ func (w *Writer) WriteTableData(meta TableMeta, ir TableDataIR, currentChunk int
 			}
 		}
 		err = ir.Start(ctx, conn)
+		if err != nil {
+			return
+		}
 		if conf.SQL != "" {
 			meta, err = setTableMetaFromRows(ir.RawRows())
 			if err != nil {
 				return err
 			}
-		}
-		if err != nil {
-			return
 		}
 		defer ir.Close()
 		return w.tryToWriteTableData(ctx, meta, ir, currentChunk)


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/pingcap/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md

You can use it with query parameters: https://github.com/pingcap/dumpling/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When `conf.SQL` is specified and query is failed, dumpling will panic.

### What is changed and how it works?
Check error before we use ir.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
- fix the problem that dumpling panic when meeting an error at executing `--sql` 