### PR TITLE
gcs: fix dumpling bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/fsouza/fake-gcs-server v1.19.0 // indirect
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/golang/mock v1.4.4 // indirect
-	github.com/google/uuid v1.1.1
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/onsi/ginkgo v1.11.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/fsouza/fake-gcs-server v1.19.0 // indirect
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/golang/mock v1.4.4 // indirect
+	github.com/google/uuid v1.1.1
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/onsi/ginkgo v1.11.0 // indirect

--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -549,10 +549,11 @@ const (
 	// DefaultTableFilter is the default exclude table filter. It will exclude all system databases
 	DefaultTableFilter = "!/^(mysql|sys|INFORMATION_SCHEMA|PERFORMANCE_SCHEMA|METRICS_SCHEMA|INSPECTION_SCHEMA)$/.*"
 
-	defaultDumpThreads         = 128
-	defaultDumpGCSafePointTTL  = 5 * 60
-	dumplingServiceSafePointID = "dumpling"
-	defaultEtcdDialTimeOut     = 3 * time.Second
+	defaultDumpThreads        = 128
+	defaultDumpGCSafePointTTL = 5 * 60
+	defaultEtcdDialTimeOut    = 3 * time.Second
+
+	dumplingServiceSafePointPrefix = "dumpling"
 )
 
 var (

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -8,7 +8,6 @@ import (
 	"database/sql"
 	"fmt"
 	"math/big"
-	"math/rand"
 	"strings"
 	"time"
 
@@ -776,8 +775,7 @@ func tidbStartGCSavepointUpdateService(d *Dumper) error {
 func updateServiceSafePoint(ctx context.Context, pdClient pd.Client, ttl int64, snapshotTS uint64) {
 	updateInterval := time.Duration(ttl/2) * time.Second
 	tick := time.NewTicker(updateInterval)
-	rand.Seed(time.Now().UnixNano())
-	dumplingServiceSafePointID := fmt.Sprintf("%s_%04d", dumplingServiceSafePointPrefix, rand.Int()%10000)
+	dumplingServiceSafePointID := fmt.Sprintf("%s_%d", dumplingServiceSafePointPrefix, time.Now().UnixNano())
 	log.Info("generate dumpling gc safePoint id", zap.String("id", dumplingServiceSafePointID))
 
 	for {

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math/big"
+	"math/rand"
 	"strings"
 	"time"
 
@@ -15,7 +16,6 @@ import (
 
 	// import mysql driver
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/google/uuid"
 	"github.com/pingcap/br/pkg/storage"
 	"github.com/pingcap/br/pkg/summary"
 	"github.com/pingcap/errors"
@@ -776,7 +776,9 @@ func tidbStartGCSavepointUpdateService(d *Dumper) error {
 func updateServiceSafePoint(ctx context.Context, pdClient pd.Client, ttl int64, snapshotTS uint64) {
 	updateInterval := time.Duration(ttl/2) * time.Second
 	tick := time.NewTicker(updateInterval)
-	dumplingServiceSafePoint := dumplingServiceSafePointID + "_" + uuid.New().String()
+	rand.Seed(time.Now().UnixNano())
+	dumplingServiceSafePoint := dumplingServiceSafePointID + "_" + fmt.Sprintf("%04d", rand.Int()%10000)
+	log.Info("generate dumpling safePoint", zap.String("id", dumplingServiceSafePoint))
 
 	for {
 		log.Debug("update PD safePoint limit with ttl",

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -15,6 +15,7 @@ import (
 
 	// import mysql driver
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/google/uuid"
 	"github.com/pingcap/br/pkg/storage"
 	"github.com/pingcap/br/pkg/summary"
 	"github.com/pingcap/errors"
@@ -775,13 +776,14 @@ func tidbStartGCSavepointUpdateService(d *Dumper) error {
 func updateServiceSafePoint(ctx context.Context, pdClient pd.Client, ttl int64, snapshotTS uint64) {
 	updateInterval := time.Duration(ttl/2) * time.Second
 	tick := time.NewTicker(updateInterval)
+	dumplingServiceSafePoint := dumplingServiceSafePointID + "_" + uuid.New().String()
 
 	for {
 		log.Debug("update PD safePoint limit with ttl",
 			zap.Uint64("safePoint", snapshotTS),
 			zap.Int64("ttl", ttl))
 		for retryCnt := 0; retryCnt <= 10; retryCnt++ {
-			_, err := pdClient.UpdateServiceGCSafePoint(ctx, dumplingServiceSafePointID, ttl, snapshotTS)
+			_, err := pdClient.UpdateServiceGCSafePoint(ctx, dumplingServiceSafePoint, ttl, snapshotTS)
 			if err == nil {
 				break
 			}

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -777,15 +777,15 @@ func updateServiceSafePoint(ctx context.Context, pdClient pd.Client, ttl int64, 
 	updateInterval := time.Duration(ttl/2) * time.Second
 	tick := time.NewTicker(updateInterval)
 	rand.Seed(time.Now().UnixNano())
-	dumplingServiceSafePoint := dumplingServiceSafePointID + "_" + fmt.Sprintf("%04d", rand.Int()%10000)
-	log.Info("generate dumpling safePoint", zap.String("id", dumplingServiceSafePoint))
+	dumplingServiceSafePointID := fmt.Sprintf("%s_%04d", dumplingServiceSafePointPrefix, rand.Int()%10000)
+	log.Info("generate dumpling gc safePoint id", zap.String("id", dumplingServiceSafePointID))
 
 	for {
 		log.Debug("update PD safePoint limit with ttl",
 			zap.Uint64("safePoint", snapshotTS),
 			zap.Int64("ttl", ttl))
 		for retryCnt := 0; retryCnt <= 10; retryCnt++ {
-			_, err := pdClient.UpdateServiceGCSafePoint(ctx, dumplingServiceSafePoint, ttl, snapshotTS)
+			_, err := pdClient.UpdateServiceGCSafePoint(ctx, dumplingServiceSafePointID, ttl, snapshotTS)
 			if err == nil {
 				break
 			}

--- a/v4/export/writer.go
+++ b/v4/export/writer.go
@@ -200,7 +200,7 @@ func (w *Writer) tryToWriteTableData(ctx context.Context, meta TableMeta, ir Tab
 	}
 
 	for {
-		fileWriter, tearDown := buildInterceptFileWriter(w.extStorage, fileName, conf.CompressType)
+		fileWriter, tearDown := buildInterceptFileWriter(ctx, w.extStorage, fileName, conf.CompressType)
 		err = format.WriteInsert(ctx, conf, meta, ir, fileWriter)
 		tearDown(ctx)
 		if err != nil {

--- a/v4/export/writer_util.go
+++ b/v4/export/writer_util.go
@@ -147,6 +147,7 @@ func WriteInsert(pCtx context.Context, cfg *Config, meta TableMeta, tblIR TableD
 
 	wp := newWriterPipe(w, cfg.FileSize, cfg.StatementSize, cfg.Labels)
 
+	// use context.Background here to make sure writerPipe can deplete all the chunks in pipeline
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -277,6 +278,7 @@ func WriteInsertInCsv(pCtx context.Context, cfg *Config, meta TableMeta, tblIR T
 		delimiter: []byte(cfg.CsvDelimiter),
 	}
 
+	// use context.Background here to make sure writerPipe can deplete all the chunks in pipeline
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -419,13 +421,13 @@ func buildFileWriter(ctx context.Context, s storage.ExternalStorage, fileName st
 	return writer, tearDownRoutine, nil
 }
 
-func buildInterceptFileWriter(s storage.ExternalStorage, fileName string, compressType storage.CompressType) (storage.ExternalFileWriter, func(context.Context)) {
+func buildInterceptFileWriter(pCtx context.Context, s storage.ExternalStorage, fileName string, compressType storage.CompressType) (storage.ExternalFileWriter, func(context.Context)) {
 	fileName += compressFileSuffix(compressType)
 	var writer storage.ExternalFileWriter
 	fullPath := path.Join(s.URI(), fileName)
 	fileWriter := &InterceptFileWriter{}
-	initRoutine := func(ctx context.Context) error {
-		w, err := storage.WithCompression(s, compressType).Create(ctx, fileName)
+	initRoutine := func() error {
+		w, err := storage.WithCompression(s, compressType).Create(pCtx, fileName)
 		if err != nil {
 			log.Error("open file failed",
 				zap.String("path", fullPath),
@@ -446,7 +448,9 @@ func buildInterceptFileWriter(s storage.ExternalStorage, fileName string, compre
 		log.Debug("tear down lazy file writer...", zap.String("path", fullPath))
 		err := writer.Close(ctx)
 		if err != nil {
-			log.Error("close file failed", zap.String("path", fullPath))
+			log.Error("close file failed",
+				zap.String("path", fullPath),
+				zap.Error(err))
 		}
 	}
 	return fileWriter, tearDownRoutine
@@ -492,13 +496,13 @@ type InterceptFileWriter struct {
 	sync.Once
 	SomethingIsWritten bool
 
-	initRoutine func(context.Context) error
+	initRoutine func() error
 	err         error
 }
 
 // Write implements storage.ExternalFileWriter.Write. It check whether writer has written something and init a file at first time
 func (w *InterceptFileWriter) Write(ctx context.Context, p []byte) (int, error) {
-	w.Do(func() { w.err = w.initRoutine(ctx) })
+	w.Do(func() { w.err = w.initRoutine() })
 	if len(p) > 0 {
 		w.SomethingIsWritten = true
 	}

--- a/v4/export/writer_util.go
+++ b/v4/export/writer_util.go
@@ -427,6 +427,8 @@ func buildInterceptFileWriter(pCtx context.Context, s storage.ExternalStorage, f
 	fullPath := path.Join(s.URI(), fileName)
 	fileWriter := &InterceptFileWriter{}
 	initRoutine := func() error {
+		// use separated context pCtx here to make sure context used in ExternalFile won't be canceled before close,
+		// which will cause a context canceled error when closing gcs's Writer
 		w, err := storage.WithCompression(s, compressType).Create(pCtx, fileName)
 		if err != nil {
 			log.Error("open file failed",


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/pingcap/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md

You can use it with query parameters: https://github.com/pingcap/dumpling/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/dumpling/issues/236
GCS's `Writer` will use the context when we create the `Writer` to close the external file. If we `teardown` after this context is canceled, it will return a `context canceled` error.

### What is changed and how it works?
Use an upper context for `ExternalStorage.Create`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
    Dumpling can write data files successfully on my GCS.


Related changes

 - Need to cherry-pick to the release branch
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
- No release note