### PR TITLE
add estimate total rows count to metrics for dump table

### DIFF
--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -209,6 +209,12 @@ func (d *Dumper) Dump() (dumpErr error) {
 		}
 	})
 
+	// get estimate total count
+	err = d.getEstimateTotalRowsCount(tctx, metaConn)
+	if err != nil {
+		return err
+	}
+
 	if conf.SQL == "" {
 		if err = d.dumpDatabases(metaConn, taskChan); err != nil {
 			return err

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -212,7 +212,7 @@ func (d *Dumper) Dump() (dumpErr error) {
 	// get estimate total count
 	err = d.getEstimateTotalRowsCount(tctx, metaConn)
 	if err != nil {
-		return err
+		tctx.L().Error("fail to get estimate total count", zap.Error(err))
 	}
 
 	if conf.SQL == "" {

--- a/v4/export/metrics.go
+++ b/v4/export/metrics.go
@@ -13,6 +13,7 @@ var (
 	finishedSizeCounter            *prometheus.CounterVec
 	finishedRowsCounter            *prometheus.CounterVec
 	finishedTablesCounter          *prometheus.CounterVec
+	estimateTotalRowsCounter       *prometheus.CounterVec
 	writeTimeHistogram             *prometheus.HistogramVec
 	receiveWriteChunkTimeHistogram *prometheus.HistogramVec
 	errorCount                     *prometheus.CounterVec
@@ -33,6 +34,13 @@ func InitMetricsVector(labels prometheus.Labels) {
 			Name:      "finished_size",
 			Help:      "counter for dumpling finished file size",
 		}, labelNames)
+	estimateTotalRowsCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "dumpling",
+			Subsystem: "dump",
+			Name:      "estimate_total_rows",
+			Help:      "estimate total rows for dumpling tables",
+		}, []string{})
 	finishedRowsCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "dumpling",
@@ -86,6 +94,7 @@ func RegisterMetrics(registry *prometheus.Registry) {
 	}
 	registry.MustRegister(finishedSizeCounter)
 	registry.MustRegister(finishedRowsCounter)
+	registry.MustRegister(estimateTotalRowsCounter)
 	registry.MustRegister(finishedTablesCounter)
 	registry.MustRegister(writeTimeHistogram)
 	registry.MustRegister(receiveWriteChunkTimeHistogram)
@@ -100,6 +109,7 @@ func RemoveLabelValuesWithTaskInMetrics(labels prometheus.Labels) {
 	}
 	finishedSizeCounter.Delete(labels)
 	finishedRowsCounter.Delete(labels)
+	estimateTotalRowsCounter.Delete(labels)
 	finishedTablesCounter.Delete(labels)
 	writeTimeHistogram.Delete(labels)
 	receiveWriteChunkTimeHistogram.Delete(labels)

--- a/v4/export/sql.go
+++ b/v4/export/sql.go
@@ -693,7 +693,12 @@ func pickupPossibleField(dbName, tableName string, db *sql.Conn, conf *Config) (
 }
 
 func estimateCount(tctx *tcontext.Context, dbName, tableName string, db *sql.Conn, field string, conf *Config) uint64 {
-	query := fmt.Sprintf("EXPLAIN SELECT `%s` FROM `%s`.`%s`", escapeString(field), escapeString(dbName), escapeString(tableName))
+	var query string
+	if strings.TrimSpace(field) == "*" || strings.TrimSpace(field) == "" {
+		query = fmt.Sprintf("EXPLAIN SELECT * FROM `%s`.`%s`", escapeString(dbName), escapeString(tableName))
+	} else {
+		query = fmt.Sprintf("EXPLAIN SELECT `%s` FROM `%s`.`%s`", escapeString(field), escapeString(dbName), escapeString(tableName))
+	}
 
 	if conf.Where != "" {
 		query += " WHERE "

--- a/v4/export/status.go
+++ b/v4/export/status.go
@@ -3,6 +3,7 @@
 package export
 
 import (
+	"database/sql"
 	"fmt"
 	"time"
 
@@ -32,10 +33,12 @@ func (d *Dumper) runLogProgress(tctx *tcontext.Context) {
 			completedTables := ReadCounter(finishedTablesCounter, conf.Labels)
 			finishedBytes := ReadCounter(finishedSizeCounter, conf.Labels)
 			finishedRows := ReadCounter(finishedRowsCounter, conf.Labels)
+			estimateTotalRows := ReadCounter(estimateTotalRowsCounter, conf.Labels)
 
 			tctx.L().Info("progress",
 				zap.String("tables", fmt.Sprintf("%.0f/%.0f (%.1f%%)", completedTables, totalTables, completedTables/totalTables*100)),
 				zap.String("finished rows", fmt.Sprintf("%.0f", finishedRows)),
+				zap.String("estimate total rows", fmt.Sprintf("%.0f", estimateTotalRows)),
 				zap.String("finished size", units.HumanSize(finishedBytes)),
 				zap.Float64("average speed(MiB/s)", (finishedBytes-lastBytes)/(1048576e-9*nanoseconds)),
 			)
@@ -56,4 +59,24 @@ func calculateTableCount(m DatabaseTables) int {
 		}
 	}
 	return cnt
+}
+
+func (d *Dumper) getEstimateTotalRowsCount(tctx *tcontext.Context, conn *sql.Conn) error {
+	conf := d.conf
+	var totalCount uint64
+	for db, tables := range conf.Tables {
+		for _, m := range tables {
+			if m.Type == TableTypeBase {
+				// get pk or uk for explain
+				field, err := pickupPossibleField(db, m.Name, conn, conf)
+				if err != nil {
+					return err
+				}
+				c := estimateCount(tctx, db, m.Name, conn, field, conf)
+				totalCount += c
+			}
+		}
+	}
+	estimateTotalRowsCounter.With(conf.Labels).Add(float64(totalCount))
+	return nil
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
add estimate total rows count

### What is changed and how it works?
add prometheus metrics to save estimate_total_rows before you dump data

### Limitation
it does not work for `-S or --sql` and views data
