### PR TITLE
dump: fix the problem that dumpling gets stuck after the database connection is lost

### DIFF
--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -560,7 +560,7 @@ const (
 
 var (
 	gcSafePointVersion = semver.New("4.0.0")
-	tableSampleVersion = semver.New("5.0.0")
+	tableSampleVersion = semver.New("5.0.0-nightly")
 )
 
 // ServerInfo is the combination of ServerType and ServerInfo

--- a/v4/export/dump_test.go
+++ b/v4/export/dump_test.go
@@ -1,0 +1,56 @@
+// Copyright 2020 PingCAP, Inc. Licensed under Apache-2.0.
+
+package export
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pingcap/errors"
+	"golang.org/x/sync/errgroup"
+
+	tcontext "github.com/pingcap/dumpling/v4/context"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	. "github.com/pingcap/check"
+)
+
+func (s *testSQLSuite) TestDumpBlock(c *C) {
+	db, mock, err := sqlmock.New()
+	c.Assert(err, IsNil)
+	defer db.Close()
+
+	database := "test"
+	mock.ExpectQuery(fmt.Sprintf("SHOW CREATE DATABASE `%s`", escapeString(database))).
+		WillReturnRows(sqlmock.NewRows([]string{"Database", "Create Database"}).
+			AddRow("test", "CREATE DATABASE `test` /*!40100 DEFAULT CHARACTER SET utf8mb4 */"))
+
+	tctx, cancel := tcontext.Background().WithCancel()
+	defer cancel()
+	conn, err := db.Conn(tctx)
+	c.Assert(err, IsNil)
+
+	d := &Dumper{
+		tctx:      tctx,
+		conf:      DefaultConfig(),
+		cancelCtx: cancel,
+	}
+	wg, writingCtx := errgroup.WithContext(tctx)
+	writerErr := errors.New("writer error")
+
+	wg.Go(func() error {
+		return writerErr
+	})
+	wg.Go(func() error {
+		time.Sleep(time.Second)
+		return context.Canceled
+	})
+	writerCtx := tctx.WithContext(writingCtx)
+	// simulate taskChan is full
+	taskChan := make(chan Task, 1)
+	taskChan <- &TaskDatabaseMeta{}
+	d.conf.Tables = DatabaseTables{}.AppendTable("test", nil)
+	c.Assert(errors.ErrorEqual(d.dumpDatabases(writerCtx, conn, taskChan), context.Canceled), IsTrue)
+	c.Assert(errors.ErrorEqual(wg.Wait(), writerErr), IsTrue)
+}

--- a/v4/export/dump_test.go
+++ b/v4/export/dump_test.go
@@ -7,13 +7,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pingcap/errors"
-	"golang.org/x/sync/errgroup"
-
 	tcontext "github.com/pingcap/dumpling/v4/context"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	. "github.com/pingcap/check"
+	"github.com/pingcap/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 func (s *testSQLSuite) TestDumpBlock(c *C) {

--- a/v4/export/dump_test.go
+++ b/v4/export/dump_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
 
 package export
 

--- a/v4/export/dump_test.go
+++ b/v4/export/dump_test.go
@@ -39,7 +39,7 @@ func (s *testSQLSuite) TestDumpBlock(c *C) {
 	writerErr := errors.New("writer error")
 
 	wg.Go(func() error {
-		return writerErr
+		return errors.Trace(writerErr)
 	})
 	wg.Go(func() error {
 		time.Sleep(time.Second)

--- a/v4/export/sql_type.go
+++ b/v4/export/sql_type.go
@@ -18,6 +18,7 @@ var (
 )
 
 func initColTypeRowReceiverMap() {
+	colTypeRowReceiverMap = map[string]func() RowReceiverStringer{}
 	for _, s := range dataTypeString {
 		colTypeRowReceiverMap[s] = SQLTypeStringMaker
 	}

--- a/v4/export/sql_type.go
+++ b/v4/export/sql_type.go
@@ -18,7 +18,6 @@ var (
 )
 
 func initColTypeRowReceiverMap() {
-	colTypeRowReceiverMap = map[string]func() RowReceiverStringer{}
 	for _, s := range dataTypeString {
 		colTypeRowReceiverMap[s] = SQLTypeStringMaker
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/pingcap/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md

You can use it with query parameters: https://github.com/pingcap/dumpling/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix https://github.com/pingcap/dumpling/issues/243

### What is changed and how it works?
Use `writerCtx` to avoid `taskChan` get blocked after the writer quitted. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
- fix the problem that dumpling gets stuck after the database connection is lost