### PR TITLE
dump: add split big tidb query to several small queries

### DIFF
--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -390,7 +390,7 @@ func (d *Dumper) buildConcatTask(tctx *tcontext.Context, conn *sql.Conn, meta Ta
 						return nil, nil
 					}
 				}
-				return NewTaskTableData(meta, newTableDataChunks(queries, colLen), 0, 1), nil
+				return NewTaskTableData(meta, newMultiQueriesChunk(queries, colLen), 0, 1), nil
 			}
 			return nil, err
 		case task := <-tableChan:
@@ -435,7 +435,6 @@ func (d *Dumper) sequentialDumpTable(tctx *tcontext.Context, conn *sql.Conn, met
 }
 
 // concurrentDumpTable tries to split table into several chunks to dump
-// return (whether we should try to dump table serial, error)
 func (d *Dumper) concurrentDumpTable(tctx *tcontext.Context, conn *sql.Conn, meta TableMeta, taskChan chan<- Task) error {
 	conf := d.conf
 	db, tbl := meta.DatabaseName(), meta.TableName()

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -355,11 +355,10 @@ func (d *Dumper) buildConcatTask(tctx *tcontext.Context, conn *sql.Conn, meta Ta
 		err    error
 	)
 	go func() {
+		// adjust rows to suitable rows for this table
 		d.conf.Rows = GetSuitableRows(conn, meta.DatabaseName(), meta.TableName())
-		defer func() {
-			d.conf.Rows = UnspecifiedSize
-		}()
 		linear, err = d.concurrentDumpTable(tctx, conn, meta, tableChan)
+		d.conf.Rows = UnspecifiedSize
 		if err != nil {
 			errCh <- err
 		} else {

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -371,7 +371,7 @@ func (d *Dumper) buildConcatTask(tctx *tcontext.Context, conn *sql.Conn, meta Ta
 		select {
 		case err, ok := <-errCh:
 			if !ok {
-				if !linear || len(tableDataArr) == 0 {
+				if linear || len(tableDataArr) == 0 {
 					return nil, nil
 				}
 				queries := make([]string, 0, len(tableDataArr))
@@ -419,7 +419,11 @@ func (d *Dumper) sequentialDumpTable(tctx *tcontext.Context, conn *sql.Conn, met
 			if ctxDone {
 				return tctx.Err()
 			}
+			return nil
 		}
+		tctx.L().Info("didn't build tidb concat sqls, will select all from table now",
+			zap.String("database", meta.DatabaseName()),
+			zap.String("table", meta.TableName()))
 	}
 
 	tableIR, err := SelectAllFromTable(conf, conn, meta)

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -406,7 +406,7 @@ func (d *Dumper) buildConcatTask(tctx *tcontext.Context, conn *sql.Conn, meta Ta
 	}
 }
 
-func (d *Dumper) sequentialDumpTable(tctx *tcontext.Context, conn *sql.Conn, meta TableMeta, taskChan chan<- Task, linear bool) error {
+func (d *Dumper) sequentialDumpTable(tctx *tcontext.Context, conn *sql.Conn, meta TableMeta, taskChan chan<- Task, linear bool) error { // revive:disable-line:flag-parameter
 	conf := d.conf
 	if !linear && conf.ServerInfo.ServerType == ServerTypeTiDB {
 		task, err := d.buildConcatTask(tctx, conn, meta)

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -342,7 +342,7 @@ func (d *Dumper) buildConcatTask(tctx *tcontext.Context, conn *sql.Conn, meta Ta
 	errCh := make(chan error, 1)
 	go func() {
 		// adjust rows to suitable rows for this table
-		d.conf.Rows = GetSuitableRows(conn, meta.DatabaseName(), meta.TableName())
+		d.conf.Rows = GetSuitableRows(tctx, conn, meta.DatabaseName(), meta.TableName())
 		err := d.concurrentDumpTable(tctx, conn, meta, tableChan)
 		d.conf.Rows = UnspecifiedSize
 		if err != nil {

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -408,7 +408,6 @@ func (d *Dumper) buildConcatTask(tctx *tcontext.Context, conn *sql.Conn, meta Ta
 
 func (d *Dumper) sequentialDumpTable(tctx *tcontext.Context, conn *sql.Conn, meta TableMeta, taskChan chan<- Task, linear bool) error {
 	conf := d.conf
-	var err error
 	if !linear && conf.ServerInfo.ServerType == ServerTypeTiDB {
 		task, err := d.buildConcatTask(tctx, conn, meta)
 		if err != nil {

--- a/v4/export/ir_impl.go
+++ b/v4/export/ir_impl.go
@@ -107,6 +107,9 @@ func (iter *rowIterChunks) nextRows() {
 		if err != nil {
 			return
 		}
+		if err = rows.Err(); err != nil {
+			return
+		}
 		iter.id++
 		iter.rows = rows
 		iter.hasNext = iter.rows.Next()

--- a/v4/export/sql.go
+++ b/v4/export/sql.go
@@ -268,7 +268,7 @@ func SelectTiDBRowID(db *sql.Conn, database, table string) (bool, error) {
 	return true, nil
 }
 
-// GetAVGRowLength gets suitable rows for each table
+// GetSuitableRows gets suitable rows for each table
 func GetSuitableRows(db *sql.Conn, database, table string) uint64 {
 	const (
 		defaultRows = 200000

--- a/v4/export/sql.go
+++ b/v4/export/sql.go
@@ -271,15 +271,15 @@ func SelectTiDBRowID(db *sql.Conn, database, table string) (bool, error) {
 // GetSuitableRows gets suitable rows for each table
 func GetSuitableRows(db *sql.Conn, database, table string) uint64 {
 	const (
-		defaultRows = 200000
-		maxRows     = 1000000
-		sizePerFile = 128 * 1024 * 1024 // 128MB per file by default
+		defaultRows  = 200000
+		maxRows      = 1000000
+		bytesPerFile = 128 * 1024 * 1024 // 128MB per file by default
 	)
 	avgRowLength, err := GetAVGRowLength(db, database, table)
 	if err != nil || avgRowLength == 0 {
 		return defaultRows
 	}
-	estimateRows := sizePerFile / avgRowLength
+	estimateRows := bytesPerFile / avgRowLength
 	if estimateRows > maxRows {
 		return maxRows
 	}

--- a/v4/export/sql_test.go
+++ b/v4/export/sql_test.go
@@ -355,6 +355,8 @@ func (s *testSQLSuite) TestGetSuitableRows(c *C) {
 	conn, err := db.Conn(context.Background())
 	c.Assert(err, IsNil)
 	const query = "select AVG_ROW_LENGTH from INFORMATION_SCHEMA.TABLES where table_schema=\\? and table_name=\\?;"
+	tctx, cancel := tcontext.Background().WithCancel()
+	defer cancel()
 	database := "foo"
 	table := "bar"
 
@@ -398,7 +400,7 @@ func (s *testSQLSuite) TestGetSuitableRows(c *C) {
 			mock.ExpectQuery(query).WithArgs(database, table).
 				WillReturnError(testCase.returnErr)
 		}
-		rows := GetSuitableRows(conn, database, table)
+		rows := GetSuitableRows(tctx, conn, database, table)
 		c.Assert(rows, Equals, testCase.expectedRows)
 	}
 }

--- a/v4/export/sql_test.go
+++ b/v4/export/sql_test.go
@@ -4,6 +4,7 @@ package export
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 
 	tcontext "github.com/pingcap/dumpling/v4/context"
@@ -345,6 +346,61 @@ func (s *testSQLSuite) TestShowCreateView(c *C) {
 	c.Assert(createTableSQL, Equals, "CREATE TABLE `v`(\n`a` int\n)ENGINE=MyISAM;\n")
 	c.Assert(createViewSQL, Equals, "DROP TABLE IF EXISTS `v`;\nDROP VIEW IF EXISTS `v`;\nSET @PREV_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT;\nSET @PREV_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS;\nSET @PREV_COLLATION_CONNECTION=@@COLLATION_CONNECTION;\nSET character_set_client = utf8;\nSET character_set_results = utf8;\nSET collation_connection = utf8_general_ci;\nCREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v` (`a`) AS SELECT `t`.`a` AS `a` FROM `test`.`t`;\nSET character_set_client = @PREV_CHARACTER_SET_CLIENT;\nSET character_set_results = @PREV_CHARACTER_SET_RESULTS;\nSET collation_connection = @PREV_COLLATION_CONNECTION;\n")
 	c.Assert(mock.ExpectationsWereMet(), IsNil)
+}
+
+func (s *testSQLSuite) TestGetSuitableRows(c *C) {
+	db, mock, err := sqlmock.New()
+	c.Assert(err, IsNil)
+	defer db.Close()
+	conn, err := db.Conn(context.Background())
+	c.Assert(err, IsNil)
+	const query = "select AVG_ROW_LENGTH from INFORMATION_SCHEMA.TABLES where table_schema=\\? and table_name=\\?;"
+	database := "foo"
+	table := "bar"
+
+	testCases := []struct {
+		avgRowLength uint64
+		expectedRows uint64
+		returnErr    error
+	}{
+		{
+			32,
+			200000,
+			sql.ErrNoRows,
+		},
+		{
+			0,
+			200000,
+			nil,
+		},
+		{
+			32,
+			1000000,
+			nil,
+		},
+		{
+			1024,
+			131072,
+			nil,
+		},
+		{
+			4096,
+			32768,
+			nil,
+		},
+	}
+	for _, testCase := range testCases {
+		if testCase.returnErr == nil {
+			mock.ExpectQuery(query).WithArgs(database, table).
+				WillReturnRows(sqlmock.NewRows([]string{"AVG_ROW_LENGTH"}).
+					AddRow(testCase.avgRowLength))
+		} else {
+			mock.ExpectQuery(query).WithArgs(database, table).
+				WillReturnError(testCase.returnErr)
+		}
+		rows := GetSuitableRows(conn, database, table)
+		c.Assert(rows, Equals, testCase.expectedRows)
+	}
 }
 
 func makeVersion(major, minor, patch int64, preRelease string) *semver.Version {


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/pingcap/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md

You can use it with query parameters: https://github.com/pingcap/dumpling/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Although we can make sure TiDB won't OOM through the help of TiDB tablesample. But if we didn't specify `--rows` to open tablesample, TiDB will still OOM.

### What is changed and how it works?
implement solution 2 in https://github.com/pingcap/dumpling/issues/232
Try to split the whole dump table SQL to several small queries to concatenate their results.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test:
 Test dumping 1.2TB data serially (with clustered index enabled), the data rows lines can match.
```log
[2021/03/28 22:31:00.483 +00:00] [INFO] [collector.go:212] ["backup Success summary: total backup ranges: 3, total success: 3, total failed: 0, total take(backup time): 7h12m34.659704485s, total take(real time): 7h12m34.659726417s, total size(MB): 1178105.36, avg speed(MB/s): 45.39, total rows: 2172298300"]
```
```
mysql> select count(*) from usertable;
+------------+
| count(*)   |
+------------+
| 2172298300 |
+------------+
1 row in set (11 min 59.50 sec)
```

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
- add split big tidb query to several small queries to avoid TiDB OOM