### PR TITLE
export: fix a metric not using labelNames

### DIFF
--- a/v4/export/metrics.go
+++ b/v4/export/metrics.go
@@ -40,7 +40,7 @@ func InitMetricsVector(labels prometheus.Labels) {
 			Subsystem: "dump",
 			Name:      "estimate_total_rows",
 			Help:      "estimate total rows for dumpling tables",
-		}, []string{})
+		}, labelNames)
 	finishedRowsCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "dumpling",


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
estimateTotalRowsCounter didn't respect labelNames, so panicked when using dumpling as a library and changing labelNames

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (WIP)

Side effects


Related changes
 
### Release note

- No release note
