### PR TITLE
*: cherry-pick recent PRs for dumpling v5.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/pingcap/tidb-tools v4.0.9-0.20201127090955-2707c97b3853+incompatible
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/client_model v0.2.0
+	github.com/siddontang/go-mysql v0.0.0-20200222075837-12e89848f047
 	github.com/soheilhy/cmux v0.1.4
 	github.com/spf13/pflag v1.0.5
 	github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285 // indirect

--- a/go.sum
+++ b/go.sum
@@ -766,6 +766,7 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sasha-s/go-deadlock v0.2.0/go.mod h1:StQn567HiB1fF2yJ44N9au7wOhrPS3iZqiDbRupzT10=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b h1:gQZ0qzfKHQIybLANtM3mBXNUtOfsCFXeTsnBqCsx1KM=
 github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
@@ -789,9 +790,12 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/shurcooL/vfsgen v0.0.0-20181020040650-a97a25d856ca/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd h1:ug7PpSOB5RBPK1Kg6qskGBoP3Vnj/aNYFTznWvlkGo0=
 github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
+github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726 h1:xT+JlYxNGqyT+XcU8iUrN18JYed2TvG9yN5ULG2jATM=
 github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726/go.mod h1:3yhqj7WBBfRhbBlzyOC3gUxftwsU0u8gqevxwIHQpMw=
 github.com/siddontang/go-log v0.0.0-20180807004314-8d05993dda07/go.mod h1:yFdBgwXP24JziuRl2NMUahT7nGLNOKi1SIiFxMttVD4=
+github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed h1:KMgQoLJGCq1IoZpLZE3AIffh9veYWoVlsvA4ib55TMM=
 github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed/go.mod h1:yFdBgwXP24JziuRl2NMUahT7nGLNOKi1SIiFxMttVD4=
+github.com/siddontang/go-mysql v0.0.0-20200222075837-12e89848f047 h1:boyJ8EgQN/aC3grvx8QUoJrptt7RvneezSJSCbW25a4=
 github.com/siddontang/go-mysql v0.0.0-20200222075837-12e89848f047/go.mod h1:+W4RCzesQDI11HvIkaDjS8yM36SpAnGNQ7jmTLn5BnU=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/tests/basic/run.sh
+++ b/tests/basic/run.sh
@@ -21,7 +21,7 @@ cnt=$(grep -w "(.*)" ${DUMPLING_OUTPUT_DIR}/${DB_NAME}.${TABLE_NAME}.000000000.s
 echo "records count is ${cnt}"
 [ "$cnt" = 2 ]
 
-# make sure that dumpling log contains version infomation
+## make sure that dumpling log contains version infomation
 cnt=$(grep -w "Welcome to dumpling.*Release Version.*Git Commit Hash.*Go Version" ${DUMPLING_OUTPUT_DIR}/dumpling.log|wc -l)
 echo "version info count is ${cnt}"
 [ "$cnt" = 1 ]
@@ -50,6 +50,7 @@ echo "expected 1 return error when specifying --filetype sql and --sql, actual $
 [ "$actual" = 1 ]
 
 export DUMPLING_TEST_PORT=4000
+
 # Test for --sql option.
 run_sql "drop database if exists \`$DB_NAME\`;"
 run_sql "create database \`$DB_NAME\`;"
@@ -81,12 +82,57 @@ set +e
 run_dumpling --sql "test" > ${DUMPLING_OUTPUT_DIR}/dumpling.log 2> ${DUMPLING_OUTPUT_DIR}/dumpling.err
 set -e
 
-# check stderr, should not contain panic info
+## check stderr, should not contain panic info
 actual=$(grep -w "panic" ${DUMPLING_OUTPUT_DIR}/dumpling.err|wc -l)
 echo "expected panic 0, actual ${actual}"
 [ "$actual" = 0 ]
 
-# check stdout, should contain mysql error log
+## check stdout, should contain mysql error log
 actual=$(grep -w "Error 1064: You have an error in your SQL syntax" ${DUMPLING_OUTPUT_DIR}/dumpling.log|wc -l)
 echo "expect contain Error 1064, actual ${actual}"
 [ "$actual" -ge 1 ]
+
+# TODO: Enable this after we use tidb cluster instead of mock tidb in interagtion test
+## Test for snapshot configuration
+#run_sql "drop database if exists \`$DB_NAME\`;"
+#run_sql "create database \`$DB_NAME\`;"
+#run_sql "create table \`$DB_NAME\`.\`$TABLE_NAME\` (a int);"
+#run_sql "insert into \`$DB_NAME\`.\`$TABLE_NAME\` values (1);"
+#
+#snapshot=$(run_sql "show master status" | grep "Position" | sed 's/.*Position: \([0-9]*\).*/\1/g')
+#echo "snapshot #1 is ${snapshot}"
+#run_sql "insert into \`$DB_NAME\`.\`$TABLE_NAME\` values (2);"
+#read -p "hello"
+#run_dumpling -f "$DB_NAME.$TABLE_NAME" -L ${DUMPLING_OUTPUT_DIR}/dumpling.log --snapshot $snapshot
+#cnt=$(grep -w "(.*)" ${DUMPLING_OUTPUT_DIR}/${DB_NAME}.${TABLE_NAME}.000000000.sql|wc -l)
+#echo "records count is ${cnt}"
+#[ "$cnt" = 1 ]
+#
+#snapshot=$(run_sql "select now()" | grep "now()" | sed 's/.*now(): \(.*\)/\1/g')
+#echo "snapshot #2 is ${snapshot}"
+#run_sql "insert into \`$DB_NAME\`.\`$TABLE_NAME\` values (3);"
+#run_dumpling -f "$DB_NAME.$TABLE_NAME" -L ${DUMPLING_OUTPUT_DIR}/dumpling.log --snapshot $snapshot
+#cnt=$(grep -w "(.*)" ${DUMPLING_OUTPUT_DIR}/${DB_NAME}.${TABLE_NAME}.000000000.sql|wc -l)
+#echo "records count is ${cnt}"
+#[ "$cnt" = 2 ]
+#
+## Test for params configuration
+#snapshot=$(run_sql "select now()" | grep "now()" | sed 's/.*now(): \(.*\)/\1/g')
+#echo "snapshot #3 is ${snapshot}"
+#run_sql "insert into \`$DB_NAME\`.\`$TABLE_NAME\` values (4);"
+#run_dumpling -f "$DB_NAME.$TABLE_NAME" -L ${DUMPLING_OUTPUT_DIR}/dumpling.log --params "net_read_timeout=86400,interactive_timeout=28800,wait_timeout=2147483,net_write_timeout=86400,tidb_snapshot='$snapshot'"
+#cnt=$(grep -w "(.*)" ${DUMPLING_OUTPUT_DIR}/${DB_NAME}.${TABLE_NAME}.000000000.sql|wc -l)
+#echo "records count is ${cnt}"
+#[ "$cnt" = 3 ]
+#
+#run_sql "insert into \`$DB_NAME\`.\`$TABLE_NAME\` values (3);"
+
+# Test for params configuration
+run_sql "drop database if exists \`$DB_NAME\`;"
+run_sql "create database \`$DB_NAME\`;"
+run_sql "create table \`$DB_NAME\`.\`$TABLE_NAME\` (a timestamp);"
+run_sql "insert into \`$DB_NAME\`.\`$TABLE_NAME\` values ('2020-11-01 00:00:00');"
+run_dumpling -f "$DB_NAME.$TABLE_NAME" -L ${DUMPLING_OUTPUT_DIR}/dumpling.log --params "net_read_timeout=86400,interactive_timeout=28800,wait_timeout=2147483,net_write_timeout=86400,time_zone='+00:00'"
+cnt=$(grep -w "2020-10-31 16:00:00" ${DUMPLING_OUTPUT_DIR}/${DB_NAME}.${TABLE_NAME}.000000000.sql|wc -l)
+echo "records count is ${cnt}"
+[ "$cnt" = 1 ]

--- a/tests/basic/run.sh
+++ b/tests/basic/run.sh
@@ -131,7 +131,7 @@ run_sql "drop database if exists \`$DB_NAME\`;"
 run_sql "create database \`$DB_NAME\`;"
 run_sql "create table \`$DB_NAME\`.\`$TABLE_NAME\` (a timestamp);"
 run_sql "set time_zone='+08:00'; insert into \`$DB_NAME\`.\`$TABLE_NAME\` values ('2020-11-01 00:00:00');"
-run_dumpling -f "$DB_NAME.$TABLE_NAME" -L ${DUMPLING_OUTPUT_DIR}/dumpling.log --params "net_read_timeout=86400,interactive_timeout=28800,wait_timeout=2147483,net_write_timeout=86400,time_zone='+00:00'"
+run_dumpling -f "$DB_NAME.$TABLE_NAME" -L ${DUMPLING_OUTPUT_DIR}/dumpling.log --params "net_read_timeout=86400,interactive_timeout=28800,wait_timeout=2147483,net_write_timeout=86400,time_zone=+00:00"
 cnt=$(grep -w "2020-10-31 16:00:00" ${DUMPLING_OUTPUT_DIR}/${DB_NAME}.${TABLE_NAME}.000000000.sql|wc -l)
 echo "records count is ${cnt}"
 [ "$cnt" = 1 ]

--- a/tests/basic/run.sh
+++ b/tests/basic/run.sh
@@ -102,7 +102,6 @@ echo "expect contain Error 1064, actual ${actual}"
 #snapshot=$(run_sql "show master status" | grep "Position" | sed 's/.*Position: \([0-9]*\).*/\1/g')
 #echo "snapshot #1 is ${snapshot}"
 #run_sql "insert into \`$DB_NAME\`.\`$TABLE_NAME\` values (2);"
-#read -p "hello"
 #run_dumpling -f "$DB_NAME.$TABLE_NAME" -L ${DUMPLING_OUTPUT_DIR}/dumpling.log --snapshot $snapshot
 #cnt=$(grep -w "(.*)" ${DUMPLING_OUTPUT_DIR}/${DB_NAME}.${TABLE_NAME}.000000000.sql|wc -l)
 #echo "records count is ${cnt}"
@@ -131,7 +130,7 @@ echo "expect contain Error 1064, actual ${actual}"
 run_sql "drop database if exists \`$DB_NAME\`;"
 run_sql "create database \`$DB_NAME\`;"
 run_sql "create table \`$DB_NAME\`.\`$TABLE_NAME\` (a timestamp);"
-run_sql "insert into \`$DB_NAME\`.\`$TABLE_NAME\` values ('2020-11-01 00:00:00');"
+run_sql "set time_zone='+08:00'; insert into \`$DB_NAME\`.\`$TABLE_NAME\` values ('2020-11-01 00:00:00');"
 run_dumpling -f "$DB_NAME.$TABLE_NAME" -L ${DUMPLING_OUTPUT_DIR}/dumpling.log --params "net_read_timeout=86400,interactive_timeout=28800,wait_timeout=2147483,net_write_timeout=86400,time_zone='+00:00'"
 cnt=$(grep -w "2020-10-31 16:00:00" ${DUMPLING_OUTPUT_DIR}/${DB_NAME}.${TABLE_NAME}.000000000.sql|wc -l)
 echo "records count is ${cnt}"

--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -127,7 +127,7 @@ type Config struct {
 	TiDBMemQuotaQuery  uint64
 	FileSize           uint64
 	StatementSize      uint64
-	SessionParams      map[string]interface{}
+	SessionParams      map[string]string
 	Labels             prometheus.Labels `json:"-"`
 	Tables             DatabaseTables
 }
@@ -163,7 +163,7 @@ func DefaultConfig() *Config {
 		SQL:                "",
 		TableFilter:        allFilter,
 		DumpEmptyDatabase:  true,
-		SessionParams:      make(map[string]interface{}),
+		SessionParams:      make(map[string]string),
 		OutputFileTemplate: DefaultOutputFileTemplate,
 		PosAfterConnect:    false,
 	}
@@ -392,16 +392,16 @@ func (conf *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	conf.SessionParams, err = flags.GetStringToString(flagParams)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	if conf.Threads <= 0 {
 		return errors.Errorf("--threads is set to %d. It should be greater than 0", conf.Threads)
 	}
 	if len(conf.CsvSeparator) == 0 {
 		return errors.New("--csv-separator is set to \"\". It must not be an empty string")
-	}
-
-	if conf.SessionParams == nil {
-		conf.SessionParams = make(map[string]interface{})
 	}
 
 	tablesList, err := flags.GetStringSlice(flagTablesList)
@@ -421,10 +421,6 @@ func (conf *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 		return errors.Trace(err)
 	}
 	outputFilenameFormat, err := flags.GetString(flagOutputFilenameTemplate)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	params, err := flags.GetStringToString(flagParams)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -459,10 +455,6 @@ func (conf *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 	conf.CompressType, err = ParseCompressType(compressType)
 	if err != nil {
 		return errors.Trace(err)
-	}
-
-	for k, v := range params {
-		conf.SessionParams[k] = v
 	}
 
 	err = conf.BackendOptions.ParseFromFlags(pflag.CommandLine)

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -212,6 +212,12 @@ func (d *Dumper) Dump() (dumpErr error) {
 		}
 	})
 
+	// get estimate total count
+	err = d.getEstimateTotalRowsCount(tctx, metaConn)
+	if err != nil {
+		tctx.L().Error("fail to get estimate total count", zap.Error(err))
+	}
+
 	if conf.SQL == "" {
 		if err = d.dumpDatabases(writerCtx, metaConn, taskChan); err != nil && !errors.ErrorEqual(err, context.Canceled) {
 			return err

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -8,7 +8,6 @@ import (
 	"database/sql"
 	"fmt"
 	"math/big"
-	"strconv"
 	"strings"
 	"time"
 
@@ -965,8 +964,9 @@ func setSessionParam(d *Dumper) error {
 	conf, pool := d.conf, d.dbHandle
 	si := conf.ServerInfo
 	consistency, snapshot := conf.Consistency, conf.Snapshot
+	sessionParam := conf.SessionParams
 	if si.ServerType == ServerTypeTiDB && conf.TiDBMemQuotaQuery != UnspecifiedSize {
-		conf.SessionParams[TiDBMemQuotaQueryName] = strconv.FormatUint(conf.TiDBMemQuotaQuery, 10)
+		sessionParam[TiDBMemQuotaQueryName] = conf.TiDBMemQuotaQuery
 	}
 	if snapshot != "" {
 		if si.ServerType != ServerTypeTiDB {
@@ -978,7 +978,7 @@ func setSessionParam(d *Dumper) error {
 				return err
 			}
 			if hasTiKV {
-				conf.SessionParams["tidb_snapshot"] = wrapStringWith(snapshot, "'")
+				sessionParam["tidb_snapshot"] = snapshot
 			}
 		}
 	}

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math/big"
+	"strconv"
 	"strings"
 	"time"
 
@@ -964,9 +965,8 @@ func setSessionParam(d *Dumper) error {
 	conf, pool := d.conf, d.dbHandle
 	si := conf.ServerInfo
 	consistency, snapshot := conf.Consistency, conf.Snapshot
-	sessionParam := conf.SessionParams
 	if si.ServerType == ServerTypeTiDB && conf.TiDBMemQuotaQuery != UnspecifiedSize {
-		sessionParam[TiDBMemQuotaQueryName] = conf.TiDBMemQuotaQuery
+		conf.SessionParams[TiDBMemQuotaQueryName] = strconv.FormatUint(conf.TiDBMemQuotaQuery, 10)
 	}
 	if snapshot != "" {
 		if si.ServerType != ServerTypeTiDB {
@@ -978,7 +978,7 @@ func setSessionParam(d *Dumper) error {
 				return err
 			}
 			if hasTiKV {
-				sessionParam["tidb_snapshot"] = snapshot
+				conf.SessionParams["tidb_snapshot"] = wrapStringWith(snapshot, "'")
 			}
 		}
 	}

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/br/pkg/summary"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	pclog "github.com/pingcap/log"
 	pd "github.com/tikv/pd/client"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -766,12 +767,16 @@ func runSteps(d *Dumper, steps ...func(*Dumper) error) error {
 
 func initLogger(d *Dumper) error {
 	conf := d.conf
-	var logger log.Logger
+	var (
+		logger log.Logger
+		err    error
+		props  *pclog.ZapProperties
+	)
+	// conf.Logger != nil means dumpling is used as a library
 	if conf.Logger != nil {
 		logger = log.NewAppLogger(conf.Logger)
 	} else {
-		var err error
-		logger, err = log.InitAppLogger(&log.Config{
+		logger, props, err = log.InitAppLogger(&log.Config{
 			Level:  conf.LogLevel,
 			File:   conf.LogFile,
 			Format: conf.LogFormat,
@@ -779,6 +784,7 @@ func initLogger(d *Dumper) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
+		pclog.ReplaceGlobals(logger.Logger, props)
 		cli.LogLongVersion(logger)
 	}
 	d.tctx = d.tctx.WithLogger(logger)

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -616,6 +616,9 @@ func selectTiDBTableSample(conn *sql.Conn, dbName, tableName string) (pkFields [
 	if hasImplicitRowID {
 		pkFields, pkColTypes = []string{"_tidb_rowid"}, []string{"BIGINT"}
 	}
+	if len(pkFields) == 0 {
+		return pkFields, pkVals, nil
+	}
 	query := buildTiDBTableSampleQuery(pkFields, dbName, tableName)
 	rows, err := conn.QueryContext(context.Background(), query)
 	if err != nil {

--- a/v4/export/dump_test.go
+++ b/v4/export/dump_test.go
@@ -25,7 +25,7 @@ func (s *testSQLSuite) TestDumpBlock(c *C) {
 		WillReturnRows(sqlmock.NewRows([]string{"Database", "Create Database"}).
 			AddRow("test", "CREATE DATABASE `test` /*!40100 DEFAULT CHARACTER SET utf8mb4 */"))
 
-	tctx, cancel := tcontext.Background().WithCancel()
+	tctx, cancel := tcontext.Background().WithLogger(appLogger).WithCancel()
 	defer cancel()
 	conn, err := db.Conn(tctx)
 	c.Assert(err, IsNil)

--- a/v4/export/metrics.go
+++ b/v4/export/metrics.go
@@ -40,7 +40,7 @@ func InitMetricsVector(labels prometheus.Labels) {
 			Subsystem: "dump",
 			Name:      "estimate_total_rows",
 			Help:      "estimate total rows for dumpling tables",
-		}, []string{})
+		}, labelNames)
 	finishedRowsCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "dumpling",

--- a/v4/export/metrics.go
+++ b/v4/export/metrics.go
@@ -13,6 +13,7 @@ var (
 	finishedSizeCounter            *prometheus.CounterVec
 	finishedRowsCounter            *prometheus.CounterVec
 	finishedTablesCounter          *prometheus.CounterVec
+	estimateTotalRowsCounter       *prometheus.CounterVec
 	writeTimeHistogram             *prometheus.HistogramVec
 	receiveWriteChunkTimeHistogram *prometheus.HistogramVec
 	errorCount                     *prometheus.CounterVec
@@ -33,6 +34,13 @@ func InitMetricsVector(labels prometheus.Labels) {
 			Name:      "finished_size",
 			Help:      "counter for dumpling finished file size",
 		}, labelNames)
+	estimateTotalRowsCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "dumpling",
+			Subsystem: "dump",
+			Name:      "estimate_total_rows",
+			Help:      "estimate total rows for dumpling tables",
+		}, []string{})
 	finishedRowsCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "dumpling",
@@ -86,6 +94,7 @@ func RegisterMetrics(registry *prometheus.Registry) {
 	}
 	registry.MustRegister(finishedSizeCounter)
 	registry.MustRegister(finishedRowsCounter)
+	registry.MustRegister(estimateTotalRowsCounter)
 	registry.MustRegister(finishedTablesCounter)
 	registry.MustRegister(writeTimeHistogram)
 	registry.MustRegister(receiveWriteChunkTimeHistogram)
@@ -100,6 +109,7 @@ func RemoveLabelValuesWithTaskInMetrics(labels prometheus.Labels) {
 	}
 	finishedSizeCounter.Delete(labels)
 	finishedRowsCounter.Delete(labels)
+	estimateTotalRowsCounter.Delete(labels)
 	finishedTablesCounter.Delete(labels)
 	writeTimeHistogram.Delete(labels)
 	receiveWriteChunkTimeHistogram.Delete(labels)

--- a/v4/export/sql.go
+++ b/v4/export/sql.go
@@ -849,7 +849,12 @@ func pickupPossibleField(dbName, tableName string, db *sql.Conn, conf *Config) (
 }
 
 func estimateCount(tctx *tcontext.Context, dbName, tableName string, db *sql.Conn, field string, conf *Config) uint64 {
-	query := fmt.Sprintf("EXPLAIN SELECT `%s` FROM `%s`.`%s`", escapeString(field), escapeString(dbName), escapeString(tableName))
+	var query string
+	if strings.TrimSpace(field) == "*" || strings.TrimSpace(field) == "" {
+		query = fmt.Sprintf("EXPLAIN SELECT * FROM `%s`.`%s`", escapeString(dbName), escapeString(tableName))
+	} else {
+		query = fmt.Sprintf("EXPLAIN SELECT `%s` FROM `%s`.`%s`", escapeString(field), escapeString(dbName), escapeString(tableName))
+	}
 
 	if conf.Where != "" {
 		query += " WHERE "

--- a/v4/export/sql.go
+++ b/v4/export/sql.go
@@ -511,44 +511,23 @@ func isUnknownSystemVariableErr(err error) bool {
 	return strings.Contains(err.Error(), "Unknown system variable")
 }
 
-func resetDBWithSessionParams(tctx *tcontext.Context, db *sql.DB, dsn string, params map[string]interface{}) (*sql.DB, error) {
-	support := make(map[string]interface{})
-	for k, v := range params {
-		var pv interface{}
-		if str, ok := v.(string); ok {
-			if pvi, err := strconv.ParseInt(str, 10, 64); err == nil {
-				pv = pvi
-			} else if pvf, err := strconv.ParseFloat(str, 64); err == nil {
-				pv = pvf
-			} else {
-				pv = str
-			}
-		} else {
-			pv = v
-		}
-		s := fmt.Sprintf("SET SESSION %s = ?", k)
-		_, err := db.ExecContext(tctx, s, pv)
+func resetDBWithSessionParams(tctx *tcontext.Context, db *sql.DB, dsn string, params map[string]string) (*sql.DB, error) {
+	support := make(map[string]string)
+	for param, val := range params {
+		_, err := db.ExecContext(tctx, "SET "+param+"="+val+"")
 		if err != nil {
 			if isUnknownSystemVariableErr(err) {
-				tctx.L().Info("session variable is not supported by db", zap.String("variable", k), zap.Reflect("value", v))
+				tctx.L().Info("session variable is not supported by db", zap.String("variable", param), zap.Reflect("value", val))
 				continue
 			}
 			return nil, errors.Trace(err)
 		}
 
-		support[k] = pv
+		support[param] = val
 	}
 
-	for k, v := range support {
-		var s string
-		// Wrap string with quote to handle string with space. For example, '2020-10-20 13:41:40'
-		// For --params argument, quote doesn't matter because it doesn't affect the actual value
-		if str, ok := v.(string); ok {
-			s = wrapStringWith(str, "'")
-		} else {
-			s = fmt.Sprintf("%v", v)
-		}
-		dsn += fmt.Sprintf("&%s=%s", k, url.QueryEscape(s))
+	for param, val := range support {
+		dsn += fmt.Sprintf("&%s=%s", param, url.QueryEscape(val))
 	}
 
 	newDB, err := sql.Open("mysql", dsn)

--- a/v4/export/sql_test.go
+++ b/v4/export/sql_test.go
@@ -5,13 +5,17 @@ package export
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"errors"
+	"fmt"
+	"strings"
 
 	tcontext "github.com/pingcap/dumpling/v4/context"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/coreos/go-semver/semver"
 	. "github.com/pingcap/check"
+	"github.com/siddontang/go-mysql/mysql"
 )
 
 var _ = Suite(&testSQLSuite{})
@@ -406,41 +410,66 @@ func (s *testSQLSuite) TestGetSuitableRows(c *C) {
 }
 
 func (s *testSQLSuite) TestBuildWhereClauses(c *C) {
+	db, mock, err := sqlmock.New()
+	c.Assert(err, IsNil)
+	defer db.Close()
+	conn, err := db.Conn(context.Background())
+	c.Assert(err, IsNil)
+	tctx, cancel := tcontext.Background().WithLogger(appLogger).WithCancel()
+
+	d := &Dumper{
+		tctx:      tctx,
+		conf:      DefaultConfig(),
+		cancelCtx: cancel,
+	}
+	d.conf.ServerInfo = ServerInfo{
+		ServerType:    ServerTypeTiDB,
+		ServerVersion: tableSampleVersion,
+	}
+	database := "foo"
+	table := "bar"
+
 	testCases := []struct {
 		handleColNames       []string
-		handleVals           [][]string
+		handleColTypes       []string
+		handleVals           [][]driver.Value
 		expectedWhereClauses []string
 	}{
 		{
 			[]string{},
-			[][]string{},
+			[]string{},
+			[][]driver.Value{},
 			nil,
 		},
 		{
 			[]string{"a"},
-			[][]string{{"1"}},
+			[]string{"bigint"},
+			[][]driver.Value{{1}},
 			[]string{"`a`<1", "`a`>=1"},
 		},
 		{
 			[]string{"a"},
-			[][]string{
-				{"1"},
-				{"2"},
-				{"3"},
+			[]string{"bigint"},
+			[][]driver.Value{
+				{1},
+				{2},
+				{3},
 			},
 			[]string{"`a`<1", "`a`>=1 and `a`<2", "`a`>=2 and `a`<3", "`a`>=3"},
 		},
 		{
 			[]string{"a", "b"},
-			[][]string{{"1", "2"}},
+			[]string{"bigint", "bigint"},
+			[][]driver.Value{{1, 2}},
 			[]string{"`a`<1 or(`a`=1 and `b`<2)", "`a`>1 or(`a`=1 and `b`>=2)"},
 		},
 		{
 			[]string{"a", "b"},
-			[][]string{
-				{"1", "2"},
-				{"3", "4"},
-				{"5", "6"},
+			[]string{"bigint", "bigint"},
+			[][]driver.Value{
+				{1, 2},
+				{3, 4},
+				{5, 6},
 			},
 			[]string{
 				"`a`<1 or(`a`=1 and `b`<2)",
@@ -451,9 +480,10 @@ func (s *testSQLSuite) TestBuildWhereClauses(c *C) {
 		},
 		{
 			[]string{"a", "b", "c"},
-			[][]string{
-				{"1", "2", "3"},
-				{"4", "5", "6"},
+			[]string{"bigint", "bigint", "bigint"},
+			[][]driver.Value{
+				{1, 2, 3},
+				{4, 5, 6},
 			},
 			[]string{
 				"`a`<1 or(`a`=1 and `b`<2)or(`a`=1 and `b`=2 and `c`<3)",
@@ -463,9 +493,10 @@ func (s *testSQLSuite) TestBuildWhereClauses(c *C) {
 		},
 		{
 			[]string{"a", "b", "c"},
-			[][]string{
-				{"1", "2", "3"},
-				{"1", "4", "5"},
+			[]string{"bigint", "bigint", "bigint"},
+			[][]driver.Value{
+				{1, 2, 3},
+				{1, 4, 5},
 			},
 			[]string{
 				"`a`<1 or(`a`=1 and `b`<2)or(`a`=1 and `b`=2 and `c`<3)",
@@ -475,9 +506,10 @@ func (s *testSQLSuite) TestBuildWhereClauses(c *C) {
 		},
 		{
 			[]string{"a", "b", "c"},
-			[][]string{
-				{"1", "2", "3"},
-				{"1", "2", "8"},
+			[]string{"bigint", "bigint", "bigint"},
+			[][]driver.Value{
+				{1, 2, 3},
+				{1, 2, 8},
 			},
 			[]string{
 				"`a`<1 or(`a`=1 and `b`<2)or(`a`=1 and `b`=2 and `c`<3)",
@@ -488,9 +520,10 @@ func (s *testSQLSuite) TestBuildWhereClauses(c *C) {
 		// special case: avoid return same samples
 		{
 			[]string{"a", "b", "c"},
-			[][]string{
-				{"1", "2", "3"},
-				{"1", "2", "3"},
+			[]string{"bigint", "bigint", "bigint"},
+			[][]driver.Value{
+				{1, 2, 3},
+				{1, 2, 3},
 			},
 			[]string{
 				"`a`<1 or(`a`=1 and `b`<2)or(`a`=1 and `b`=2 and `c`<3)",
@@ -498,24 +531,40 @@ func (s *testSQLSuite) TestBuildWhereClauses(c *C) {
 				"`a`>1 or(`a`=1 and `b`>2)or(`a`=1 and `b`=2 and `c`>=3)",
 			},
 		},
+		// special case: numbers has bigger lexicographically order but lower number
+		{
+			[]string{"a", "b", "c"},
+			[]string{"bigint", "bigint", "bigint"},
+			[][]driver.Value{
+				{12, 2, 3},
+				{111, 4, 5},
+			},
+			[]string{
+				"`a`<12 or(`a`=12 and `b`<2)or(`a`=12 and `b`=2 and `c`<3)",
+				"(`a`>12 and `a`<111)or(`a`=12 and(`b`>2 or(`b`=2 and `c`>=3)))or(`a`=111 and(`b`<4 or(`b`=4 and `c`<5)))", // should return sql correctly
+				"`a`>111 or(`a`=111 and `b`>4)or(`a`=111 and `b`=4 and `c`>=5)",
+			},
+		},
 		// test string fields
 		{
 			[]string{"a", "b", "c"},
-			[][]string{
-				{"1", "2", "\"3\""},
-				{"1", "4", "\"5\""},
+			[]string{"bigint", "bigint", "varchar"},
+			[][]driver.Value{
+				{1, 2, "3"},
+				{1, 4, "5"},
 			},
 			[]string{
-				"`a`<1 or(`a`=1 and `b`<2)or(`a`=1 and `b`=2 and `c`<\"3\")",
-				"`a`=1 and((`b`>2 and `b`<4)or(`b`=2 and(`c`>=\"3\"))or(`b`=4 and(`c`<\"5\")))",
-				"`a`>1 or(`a`=1 and `b`>4)or(`a`=1 and `b`=4 and `c`>=\"5\")",
+				"`a`<1 or(`a`=1 and `b`<2)or(`a`=1 and `b`=2 and `c`<'3')",
+				"`a`=1 and((`b`>2 and `b`<4)or(`b`=2 and(`c`>='3'))or(`b`=4 and(`c`<'5')))",
+				"`a`>1 or(`a`=1 and `b`>4)or(`a`=1 and `b`=4 and `c`>='5')",
 			},
 		},
 		{
 			[]string{"a", "b", "c", "d"},
-			[][]string{
-				{"1", "2", "3", "4"},
-				{"5", "6", "7", "8"},
+			[]string{"bigint", "bigint", "bigint", "bigint"},
+			[][]driver.Value{
+				{1, 2, 3, 4},
+				{5, 6, 7, 8},
 			},
 			[]string{
 				"`a`<1 or(`a`=1 and `b`<2)or(`a`=1 and `b`=2 and `c`<3)or(`a`=1 and `b`=2 and `c`=3 and `d`<4)",
@@ -524,9 +573,96 @@ func (s *testSQLSuite) TestBuildWhereClauses(c *C) {
 			},
 		},
 	}
-	for _, testCase := range testCases {
-		whereClauses := buildWhereClauses(testCase.handleColNames, testCase.handleVals)
+	transferHandleValStrings := func(handleColTypes []string, handleVals [][]driver.Value) [][]string {
+		handleValStrings := make([][]string, 0, len(handleVals))
+		for _, handleVal := range handleVals {
+			handleValString := make([]string, 0, len(handleVal))
+			for i, val := range handleVal {
+				rec := colTypeRowReceiverMap[strings.ToUpper(handleColTypes[i])]()
+				var valStr string
+				switch rec.(type) {
+				case *SQLTypeString:
+					valStr = fmt.Sprintf("'%s'", val)
+				case *SQLTypeBytes:
+					valStr = fmt.Sprintf("x'%x'", val)
+				case *SQLTypeNumber:
+					valStr = fmt.Sprintf("%d", val)
+				}
+				handleValString = append(handleValString, valStr)
+			}
+			handleValStrings = append(handleValStrings, handleValString)
+		}
+		return handleValStrings
+	}
+
+	for i, testCase := range testCases {
+		c.Log(fmt.Sprintf("case #%d", i))
+		handleColNames := testCase.handleColNames
+		handleColTypes := testCase.handleColTypes
+		handleVals := testCase.handleVals
+		handleValStrings := transferHandleValStrings(handleColTypes, handleVals)
+
+		// Test build whereClauses
+		whereClauses := buildWhereClauses(handleColNames, handleValStrings)
 		c.Assert(whereClauses, DeepEquals, testCase.expectedWhereClauses)
+
+		// Test build tasks through table sample
+		if len(handleColNames) > 0 {
+			taskChan := make(chan Task, 128)
+			quotaCols := make([]string, 0, len(handleColNames))
+			for _, col := range quotaCols {
+				quotaCols = append(quotaCols, wrapBackTicks(col))
+			}
+			selectFields := strings.Join(quotaCols, ",")
+			meta := &tableMeta{
+				database:      database,
+				table:         table,
+				selectedField: selectFields,
+				specCmts: []string{
+					"/*!40101 SET NAMES binary*/;",
+				},
+			}
+
+			rows := sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE"})
+			for i := range handleColNames {
+				rows.AddRow(handleColNames[i], handleColTypes[i])
+			}
+			mock.ExpectQuery("SELECT c.COLUMN_NAME, DATA_TYPE FROM").WithArgs(database, table).WillReturnRows(rows)
+			mock.ExpectExec(fmt.Sprintf("SELECT _tidb_rowid from `%s`.`%s` LIMIT 0", database, table)).
+				WillReturnError(&mysql.MyError{
+					Code:    mysql.ER_BAD_FIELD_ERROR,
+					State:   "42S22",
+					Message: "Unknown column '_tidb_rowid' in 'field list'",
+				})
+
+			rows = sqlmock.NewRows(handleColNames)
+			for _, handleVal := range handleVals {
+				rows.AddRow(handleVal...)
+			}
+			mock.ExpectQuery(fmt.Sprintf("SELECT .* FROM `%s`.`%s` TABLESAMPLE REGIONS", database, table)).WillReturnRows(rows)
+
+			rows = sqlmock.NewRows([]string{"COLUMN_NAME", "EXTRA"})
+			for _, handleCol := range handleColNames {
+				rows.AddRow(handleCol, "")
+			}
+			mock.ExpectQuery("SELECT COLUMN_NAME,EXTRA FROM INFORMATION_SCHEMA.COLUMNS").WithArgs(database, table).
+				WillReturnRows(rows)
+
+			c.Assert(d.concurrentDumpTable(tctx, conn, meta, taskChan), IsNil)
+			c.Assert(mock.ExpectationsWereMet(), IsNil)
+			orderByClause := buildOrderByClauseString(handleColNames)
+
+			for i, w := range testCase.expectedWhereClauses {
+				query := buildSelectQuery(database, table, "*", buildWhereCondition(d.conf, w), orderByClause)
+				task := <-taskChan
+				taskTableData, ok := task.(*TaskTableData)
+				c.Assert(ok, IsTrue)
+				c.Assert(taskTableData.ChunkIndex, Equals, i)
+				data, ok := taskTableData.Data.(*tableData)
+				c.Assert(ok, IsTrue)
+				c.Assert(data.query, Equals, query)
+			}
+		}
 	}
 }
 

--- a/v4/export/status.go
+++ b/v4/export/status.go
@@ -3,6 +3,7 @@
 package export
 
 import (
+	"database/sql"
 	"fmt"
 	"time"
 
@@ -32,10 +33,12 @@ func (d *Dumper) runLogProgress(tctx *tcontext.Context) {
 			completedTables := ReadCounter(finishedTablesCounter, conf.Labels)
 			finishedBytes := ReadCounter(finishedSizeCounter, conf.Labels)
 			finishedRows := ReadCounter(finishedRowsCounter, conf.Labels)
+			estimateTotalRows := ReadCounter(estimateTotalRowsCounter, conf.Labels)
 
 			tctx.L().Info("progress",
 				zap.String("tables", fmt.Sprintf("%.0f/%.0f (%.1f%%)", completedTables, totalTables, completedTables/totalTables*100)),
 				zap.String("finished rows", fmt.Sprintf("%.0f", finishedRows)),
+				zap.String("estimate total rows", fmt.Sprintf("%.0f", estimateTotalRows)),
 				zap.String("finished size", units.HumanSize(finishedBytes)),
 				zap.Float64("average speed(MiB/s)", (finishedBytes-lastBytes)/(1048576e-9*nanoseconds)),
 			)
@@ -56,4 +59,24 @@ func calculateTableCount(m DatabaseTables) int {
 		}
 	}
 	return cnt
+}
+
+func (d *Dumper) getEstimateTotalRowsCount(tctx *tcontext.Context, conn *sql.Conn) error {
+	conf := d.conf
+	var totalCount uint64
+	for db, tables := range conf.Tables {
+		for _, m := range tables {
+			if m.Type == TableTypeBase {
+				// get pk or uk for explain
+				field, err := pickupPossibleField(db, m.Name, conn, conf)
+				if err != nil {
+					return err
+				}
+				c := estimateCount(tctx, db, m.Name, conn, field, conf)
+				totalCount += c
+			}
+		}
+	}
+	estimateTotalRowsCounter.With(conf.Labels).Add(float64(totalCount))
+	return nil
 }

--- a/v4/export/status.go
+++ b/v4/export/status.go
@@ -77,6 +77,6 @@ func (d *Dumper) getEstimateTotalRowsCount(tctx *tcontext.Context, conn *sql.Con
 			}
 		}
 	}
-	estimateTotalRowsCounter.With(conf.Labels).Add(float64(totalCount))
+	AddCounter(estimateTotalRowsCounter, conf.Labels, float64(totalCount))
 	return nil
 }

--- a/v4/export/writer_util_test.go
+++ b/v4/export/writer_util_test.go
@@ -9,14 +9,27 @@ import (
 	"testing"
 
 	tcontext "github.com/pingcap/dumpling/v4/context"
+	"github.com/pingcap/dumpling/v4/log"
 
 	"github.com/pingcap/br/pkg/storage"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 )
 
+var appLogger log.Logger
+
 func TestT(t *testing.T) {
 	initColTypeRowReceiverMap()
+	logger, err := log.InitAppLogger(&log.Config{
+		Level:  "info",
+		File:   "",
+		Format: "text",
+	})
+	if err != nil {
+		t.Log("fail to init logger, err: " + err.Error())
+		t.Fail()
+	}
+	appLogger = logger
 	TestingT(t)
 }
 

--- a/v4/export/writer_util_test.go
+++ b/v4/export/writer_util_test.go
@@ -20,7 +20,7 @@ var appLogger log.Logger
 
 func TestT(t *testing.T) {
 	initColTypeRowReceiverMap()
-	logger, err := log.InitAppLogger(&log.Config{
+	logger, _, err := log.InitAppLogger(&log.Config{
 		Level:  "info",
 		File:   "",
 		Format: "text",

--- a/v4/log/log.go
+++ b/v4/log/log.go
@@ -38,8 +38,8 @@ type Config struct {
 }
 
 // InitAppLogger inits the wrapped logger from config.
-func InitAppLogger(cfg *Config) (Logger, error) {
-	logger, _, err := pclog.InitLogger(&pclog.Config{
+func InitAppLogger(cfg *Config) (Logger, *pclog.ZapProperties, error) {
+	logger, props, err := pclog.InitLogger(&pclog.Config{
 		Level: cfg.Level,
 		File: pclog.FileLogConfig{
 			Filename:   cfg.File,
@@ -50,9 +50,9 @@ func InitAppLogger(cfg *Config) (Logger, error) {
 		Format: cfg.Format,
 	})
 	if err != nil {
-		return appLogger, errors.Trace(err)
+		return appLogger, props, errors.Trace(err)
 	}
-	return Logger{logger.WithOptions(zap.AddStacktrace(zap.DPanicLevel))}, nil
+	return Logger{logger.WithOptions(zap.AddStacktrace(zap.DPanicLevel))}, props, nil
 }
 
 // NewAppLogger returns the wrapped logger from config.


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/pingcap/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md

You can use it with query parameters: https://github.com/pingcap/dumpling/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Some features are not cherry-picked to release-5.0.

### What is changed and how it works?
Cherry-pick PRs on the master branch to release-5.0.

BugFix:
- Fix the format problem for connection session variables. https://github.com/pingcap/dumpling/pull/265
- Fix panic bugs for metrics when used as library https://github.com/pingcap/dumpling/pull/266, https://github.com/pingcap/dumpling/pull/267
- Fix the problem that pd client's logs are not printed to dumpling's https://github.com/pingcap/dumpling/pull/270 

Feature:
- Add estimate total rows count to metrics for dump table. https://github.com/pingcap/dumpling/pull/254

Tests:
- Add more tests for sample SQL generator https://github.com/pingcap/dumpling/pull/262


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
- No release note
