### PR TITLE
support dump with UTC timezone

### DIFF
--- a/v4/export/config_test.go
+++ b/v4/export/config_test.go
@@ -18,3 +18,29 @@ func (s *testConfigSuite) TestCreateExternalStorage(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(loc.URI(), Matches, "file:.*")
 }
+
+func (s *testConfigSuite) TestGetDSN(c *C) {
+	cfg := &Config{
+		Host: "127.0.0.1",
+		Port: 4000,
+		User: "root",
+		Password: "123",
+	}
+
+	baseDSN := "root:123@tcp(127.0.0.1:4000)/test?collation=utf8mb4_general_ci&readTimeout=0s&writeTimeout=30s&interpolateParams=true&maxAllowedPacket=0"
+	dsn := cfg.GetDSN("test")
+	c.Assert(dsn, Equals, baseDSN)
+
+	cfg.Security.CAPath = "/path/test"
+	dsn = cfg.GetDSN("test")
+	c.Assert(dsn, Equals, baseDSN + "&tls=dumpling-tls-target")
+
+	cfg.Security.CAPath = ""
+	cfg.AllowCleartextPasswords = true
+	dsn = cfg.GetDSN("test")
+	c.Assert(dsn, Equals, baseDSN + "&allowCleartextPasswords=1")
+
+	cfg.TimeZone = "+00:00"
+	dsn = cfg.GetDSN("test")
+	c.Assert(dsn, Equals, baseDSN + "&allowCleartextPasswords=1&time_zone=%27%2B00%3A00%27")
+}

--- a/v4/export/writer_test.go
+++ b/v4/export/writer_test.go
@@ -53,6 +53,14 @@ func (s *testWriterSuite) TestWriteDatabaseMeta(c *C) {
 	bytes, err := ioutil.ReadFile(p)
 	c.Assert(err, IsNil)
 	c.Assert(string(bytes), Equals, "/*!40101 SET NAMES binary*/;\nCREATE DATABASE `test`;\n")
+
+	config.TimeZone = "+00:00"
+	err = writer.WriteDatabaseMeta("test", "CREATE DATABASE `test`")
+	c.Assert(err, IsNil)
+	bytes, err = ioutil.ReadFile(p)
+	c.Assert(err, IsNil)
+	c.Assert(string(bytes), Equals, "/*!40101 SET NAMES binary*/;\n/*!40103 SET TIME_ZONE='+00:00' */;\nCREATE DATABASE `test`;\n")
+
 }
 
 func (s *testWriterSuite) TestWriteTableMeta(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/pingcap/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md

You can use it with query parameters: https://github.com/pingcap/dumpling/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Support the `--tz-utc` config to dump timestamp value with UTC time_zone.

### What is changed and how it works?
If set the `--tz-utc` command line parameter:
- Add comment `/*!40103 SET TIME_ZONE='+00:00' */;` for each schema and data files.
- Set `time_zone='+00:00'` parameter to the DSN 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support --tz-utc argument

or if no need to be included in the release note, just add the following line

- No release note
-->
