### PR TITLE
external-storage: replace storage.Create by storage.New

### DIFF
--- a/v4/export/config.go
+++ b/v4/export/config.go
@@ -537,7 +537,8 @@ func (conf *Config) createExternalStorage(ctx context.Context) (storage.External
 	httpClient.Transport = transport
 
 	return storage.New(ctx, b, &storage.ExternalStorageOptions{
-		HTTPClient: httpClient,
+		HTTPClient:    httpClient,
+		SkipCheckPath: true,
 	})
 }
 

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -963,11 +963,7 @@ func initLogger(d *Dumper) error {
 // createExternalStore is an initialization step of Dumper.
 func createExternalStore(d *Dumper) error {
 	tctx, conf := d.tctx, d.conf
-	b, err := storage.ParseBackend(conf.OutputDirPath, &conf.BackendOptions)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	extStore, err := storage.Create(tctx, b, false)
+	extStore, err := conf.createExternalStorage(tctx)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/v4/export/writer_test.go
+++ b/v4/export/writer_test.go
@@ -12,7 +12,6 @@ import (
 	tcontext "github.com/pingcap/dumpling/v4/context"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/pingcap/br/pkg/storage"
 	. "github.com/pingcap/check"
 )
 
@@ -27,9 +26,7 @@ func defaultConfigForTest(c *C) *Config {
 }
 
 func (s *testWriterSuite) newWriter(conf *Config, c *C) *Writer {
-	b, err := storage.ParseBackend(conf.OutputDirPath, &conf.BackendOptions)
-	c.Assert(err, IsNil)
-	extStore, err := storage.Create(context.Background(), b, false)
+	extStore, err := conf.createExternalStorage(context.Background())
 	c.Assert(err, IsNil)
 	db, _, err := sqlmock.New()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/pingcap/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md

You can use it with query parameters: https://github.com/pingcap/dumpling/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
1. `storage.Create` has been deprecated... so let's replace the remaining two calls from Dumpling.
2. Dumpling originally used storage.Create(sendCreds=true), but
the entire cloud access happens within Lightning, so we don't need to send credentials to anyone
this introduced skipCheckPath=false.

### What is changed and how it works?
Changed `storage.Create` to `storage.New` with sendCreds=false and skipCheckPath=true.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

Related changes
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- When using Dumpling to export to S3, we no longer require s3:ListBucket permission on the entire bucket, only the data source prefix itself.

or if no need to be included in the release note, just add the following line

- No release note
-->
- When using Dumpling to export to S3, we no longer require s3:ListBucket permission on the entire bucket, only the data source prefix itself.