### PR TITLE
*: use different connetion in consistencyTypeFlush

### DIFF
--- a/v4/export/consistency.go
+++ b/v4/export/consistency.go
@@ -100,7 +100,6 @@ func (c *ConsistencyFlushTableWithReadLock) TearDown(ctx context.Context) error 
 	if c.conn == nil {
 		c.conn, err = c.session.Conn(ctx)
 		if err != nil {
-			println("err,", err.Error())
 			return errors.Trace(err)
 		}
 	}

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -1033,7 +1033,6 @@ func openSQLDB(d *Dumper) error {
 // detectServerInfo is an initialization step of Dumper.
 func detectServerInfo(d *Dumper) error {
 	db, conf := d.dbHandle, d.conf
-	defer db.Close()
 	versionStr, err := SelectVersion(db)
 	if err != nil {
 		conf.ServerInfo = ServerInfoUnknown

--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -1033,6 +1033,7 @@ func openSQLDB(d *Dumper) error {
 // detectServerInfo is an initialization step of Dumper.
 func detectServerInfo(d *Dumper) error {
 	db, conf := d.dbHandle, d.conf
+	defer db.Close()
 	versionStr, err := SelectVersion(db)
 	if err != nil {
 		conf.ServerInfo = ServerInfoUnknown


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/pingcap/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md

You can use it with query parameters: https://github.com/pingcap/dumpling/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

https://github.com/pingcap/dumpling/issues/322

### What is changed and how it works?

use different mysql connetion between `FLUSH TABLES WITH READ LOCK` and `unlock tables`
 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

 - Possible performance regression
 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 
### Release note

- fix pending on dump when use  mysql 8.0.19




