### PR TITLE
dump: fix dump TiDB snapshot inconsistent problem

### DIFF
--- a/v4/export/dump.go
+++ b/v4/export/dump.go
@@ -92,6 +92,7 @@ func (d *Dumper) Dump() (dumpErr error) {
 	tctx, conf, pool := d.tctx, d.conf, d.dbHandle
 	tctx.L().Info("begin to run Dump", zap.Stringer("conf", conf))
 	m := newGlobalMetadata(tctx, d.extStore, conf.Snapshot)
+	repeatableRead := needRepeatableRead(conf.ServerInfo.ServerType, conf.Consistency)
 	defer func() {
 		if dumpErr == nil {
 			_ = m.writeGlobalMetaData()
@@ -100,7 +101,7 @@ func (d *Dumper) Dump() (dumpErr error) {
 
 	// for consistency lock, we should get table list at first to generate the lock tables SQL
 	if conf.Consistency == consistencyTypeLock {
-		conn, err = createConn(tctx, pool, withConsistency(conf.ServerInfo, conf.Consistency))
+		conn, err = createConnWithConsistency(tctx, pool, repeatableRead)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -126,7 +127,7 @@ func (d *Dumper) Dump() (dumpErr error) {
 		}
 	}()
 
-	metaConn, err := createConn(tctx, pool, withConsistency(conf.ServerInfo, conf.Consistency))
+	metaConn, err := createConnWithConsistency(tctx, pool, repeatableRead)
 	if err != nil {
 		return err
 	}
@@ -161,7 +162,7 @@ func (d *Dumper) Dump() (dumpErr error) {
 		}
 		// give up the last broken connection
 		conn.Close()
-		newConn, err1 := createConn(tctx, pool, withConsistency(conf.ServerInfo, conf.Consistency))
+		newConn, err1 := createConnWithConsistency(tctx, pool, repeatableRead)
 		if err1 != nil {
 			return conn, errors.Trace(err1)
 		}
@@ -251,7 +252,7 @@ func (d *Dumper) startWriters(tctx *tcontext.Context, wg *errgroup.Group, taskCh
 	conf, pool := d.conf, d.dbHandle
 	writers := make([]*Writer, conf.Threads)
 	for i := 0; i < conf.Threads; i++ {
-		conn, err := createConn(tctx, pool, withConsistency(conf.ServerInfo, conf.Consistency))
+		conn, err := createConnWithConsistency(tctx, pool, needRepeatableRead(conf.ServerInfo.ServerType, conf.Consistency))
 		if err != nil {
 			return nil, func() {}, err
 		}

--- a/v4/export/sql.go
+++ b/v4/export/sql.go
@@ -680,13 +680,13 @@ func resetDBWithSessionParams(tctx *tcontext.Context, db *sql.DB, dsn string, pa
 	return newDB, errors.Trace(err)
 }
 
-func createConn(ctx context.Context, db *sql.DB, withConsistency bool) (*sql.Conn, error) {
+func createConnWithConsistency(ctx context.Context, db *sql.DB, repeatableRead bool) (*sql.Conn, error) {
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	var query string
-	if withConsistency {
+	if repeatableRead {
 		query = "SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ"
 		_, err = conn.ExecContext(ctx, query)
 		if err != nil {

--- a/v4/export/util.go
+++ b/v4/export/util.go
@@ -75,6 +75,6 @@ func string2Map(a, b []string) map[string]string {
 	return a2b
 }
 
-func withConsistency(info ServerInfo, consistency string) bool {
-	return consistency != consistencyTypeSnapshot || info.ServerType != ServerTypeTiDB
+func needRepeatableRead(serverType ServerType, consistency string) bool {
+	return consistency != consistencyTypeSnapshot || serverType != ServerTypeTiDB
 }

--- a/v4/export/util_test.go
+++ b/v4/export/util_test.go
@@ -1,0 +1,32 @@
+// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+
+package export
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepeatableRead(t *testing.T) {
+	t.Parallel()
+
+	data := [][]interface{}{
+		{ServerTypeUnknown, consistencyTypeNone, true},
+		{ServerTypeMySQL, consistencyTypeFlush, true},
+		{ServerTypeMariaDB, consistencyTypeLock, true},
+		{ServerTypeTiDB, consistencyTypeNone, true},
+		{ServerTypeTiDB, consistencyTypeSnapshot, false},
+		{ServerTypeTiDB, consistencyTypeLock, true},
+	}
+	dec := func(d []interface{}) (ServerType, string, bool) {
+		return ServerType(d[0].(int)), d[1].(string), d[2].(bool)
+	}
+	for tag, datum := range data {
+		serverTp, consistency, expectRepeatableRead := dec(datum)
+		comment := fmt.Sprintf("test case number: %d", tag)
+		rr := needRepeatableRead(serverTp, consistency)
+		require.True(t, rr == expectRepeatableRead, comment)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/pingcap/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md

You can use it with query parameters: https://github.com/pingcap/dumpling/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The number of files exported by dumpling may not match the timestamp indicated in metadata if there are changes to the library table data during the TiDB export using Dumpling default configuration.

If we sets another session variable (not the snapshot variable) in the problematic version of TiDB after setting the snapshot, it will clear the previously set snapshot variable and dumpling will export data in a non-snapshot status. Dumpling will configure SESSION TRANSACTION ISOLATION LEVEL after setting snapshot, which will trigger this issue.

### What is changed and how it works?
Don't set `SESSION TRANSACTION ISOLATION LEVEL` for specific TiDB versions.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
  Test using dumpling dump problematic versions of TiDB, can get correct result.

Related changes

 - Need to cherry-pick to the release branch
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
- fix dump TiDB snapshot inconsistent problem