### PR TITLE
sql: fix where condition without brackets problem

### DIFF
--- a/tests/basic/run.sh
+++ b/tests/basic/run.sh
@@ -40,7 +40,7 @@ expected=$(seq 3 9)
 echo "expected ${expected}, actual ${actual}"
 [ "$actual" = "$expected" ]
 
-# Test for OR WHERE case. **Must dump MySQL here!!**
+# Test for OR WHERE case. Better dump MySQL here because Dumpling has some special handle for concurrently dump TiDB tables.
 export DUMPLING_TEST_PORT=3306
 run_sql "drop database if exists \`$DB_NAME\`;"
 run_sql "create database \`$DB_NAME\`;"

--- a/v4/export/sql.go
+++ b/v4/export/sql.go
@@ -1078,8 +1078,8 @@ func buildWhereCondition(conf *Config, where string) string {
 	leftBracket := " "
 	rightBracket := " "
 	if conf.Where != "" && where != "" {
-		leftBracket = "("
-		rightBracket = ")"
+		leftBracket = " ("
+		rightBracket = ") "
 	}
 	if conf.Where != "" {
 		query.WriteString(separator)

--- a/v4/export/sql_test.go
+++ b/v4/export/sql_test.go
@@ -855,7 +855,7 @@ func TestBuildWhereCondition(t *testing.T) {
 		{
 			"a >= 1000000 and a <= 2000000",
 			"(`a`>1 and `a`<3)or(`a`=1 and(`b`>=2))or(`a`=3 and(`b`<4))",
-			"WHERE(a >= 1000000 and a <= 2000000)AND((`a`>1 and `a`<3)or(`a`=1 and(`b`>=2))or(`a`=3 and(`b`<4)))",
+			"WHERE (a >= 1000000 and a <= 2000000) AND ((`a`>1 and `a`<3)or(`a`=1 and(`b`>=2))or(`a`=3 and(`b`<4))) ",
 		},
 	}
 	for _, testCase := range testCases {


### PR DESCRIPTION
<!--
Thank you for contributing to Dumpling! Please read the [CONTRIBUTING](https://github.com/pingcap/dumpling/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/pingcap/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md

You can use it with query parameters: https://github.com/pingcap/dumpling/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/dumpling/issues/371

### What is changed and how it works?
If both `conf.Where` and `where` has a value, we use brackets to wrap these two conditions.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
  Dumpling before this commit can't pass new integration tests.

Side effects

 - Possible performance regression

Related changes

 - Need to cherry-pick to the release branch
 
### Release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- support -T/--tables-list argument

or if no need to be included in the release note, just add the following line

- No release note
-->
- fix the problem that dumpling may dump extra data if --where is specified